### PR TITLE
LUI-46: Fix path for download dictionary servlet

### DIFF
--- a/omod/src/main/webapp/admin/dictionary/index.jsp
+++ b/omod/src/main/webapp/admin/dictionary/index.jsp
@@ -80,7 +80,7 @@
 
 <h2><openmrs:message code="dictionary.title" /></h2>
 
-<a href="<%= request.getContextPath() %>/downloadDictionary.csv"><openmrs:message code="dictionary.download.link"/></a> <openmrs:message code="dictionary.download.description"/><br />
+<a href="<%= request.getContextPath() %>/moduleServlet/legacyui/downloadDictionaryServlet"><openmrs:message code="dictionary.download.link"/></a> <openmrs:message code="dictionary.download.description"/><br />
 <br />
 
 <openmrs:hasPrivilege privilege="Manage Concepts">

--- a/omod/src/main/webapp/dictionary/index.jsp
+++ b/omod/src/main/webapp/dictionary/index.jsp
@@ -80,7 +80,7 @@
 
 <h2><openmrs:message code="dictionary.title" /></h2>
 
-<a href="<%= request.getContextPath() %>/downloadDictionary.csv"><openmrs:message code="dictionary.download.link"/></a> <openmrs:message code="dictionary.download.description"/><br />
+<a href="<%= request.getContextPath() %>/moduleServlet/legacyui/downloadDictionaryServlet"><openmrs:message code="dictionary.download.link"/></a> <openmrs:message code="dictionary.download.description"/><br />
 <br />
 
 <openmrs:hasPrivilege privilege="Manage Concepts">

--- a/omod/src/test/java/org/openmrs/web/servlet/DownloadDictionaryServletTest.java
+++ b/omod/src/test/java/org/openmrs/web/servlet/DownloadDictionaryServletTest.java
@@ -95,7 +95,7 @@ public class DownloadDictionaryServletTest extends BaseModuleWebContextSensitive
 	
 	private String runServletWithConcepts(Concept... concepts) throws Exception {
 		DownloadDictionaryServlet downloadServlet = new DownloadDictionaryServlet();
-		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/downloadDictionary.csv");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/moduleServlet/legacyui/downloadDictionaryServlet");
 		request.setContextPath("/somecontextpath");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		


### PR DESCRIPTION
Updated servlet path to point to legacyui: /moduleServlet/legacyui