### PR TITLE
LUI-45. Fixed code. Unable to write tests

### DIFF
--- a/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
@@ -1,0 +1,56 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.controller;
+
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Test the different aspects of
+ * {@link org.openmrs.web.controller.ForgotPasswordFormController}
+ */
+public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensitiveTest {
+
+	protected static final String TEST_DATA= "org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml";
+
+	@Before
+	public void updateSearchIndex() {
+		super.updateSearchIndex();
+	}
+
+	/**
+	 * Check to see if the admin's secret question comes back
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldNotNotFailOnNotFoundUsernameTEST() throws Exception {
+		executeDataSet(TEST_DATA);
+
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		request.setParameter("uname", "bruno");
+		request.setParameter("secretAnswer", "valid secret answer");
+		request.setMethod("POST");
+
+		controller.handleRequest(request, response);
+
+		Assert.assertEquals("what is your name bruno?", request.getParameter("secretQuestion"));
+	}
+
+}

--- a/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
+++ b/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+    <users user_id="952" person_id="1" system_id="952-6" username="bruno" password="ff6d1655327d385e11a04e1632b4f33ceb8fafd2" salt="5d32c5fd9fde391c755f1f4dfd5e1d6e3debe6" secret_question="what is your name bruno?" creator="1" date_created="2008-08-15 15:46:47.0" changed_by="1" date_changed="2008-08-15 15:47:07.0" retired="true" retire_reason="Test purposes" uuid="3d46f727-c59d-4c5c-b82b-0243715ed4b1"/>
+    <users user_id="953" person_id="2" system_id="953-4" username="butch" password="eeeda5c0cc3837151b2d61cfeab54a91fb0c27d" salt="42af4c437a47cd778a54f6564d71b3cd6e8e5ca" secret_question="" creator="1" date_created="2008-08-15 15:57:09.0" changed_by="1" date_changed="2008-08-18 11:51:56.0" retired="false" retire_reason="" uuid="28816eed-6ca8-4850-8f3c-8e9ea64a3d97"/>
+</dataset>


### PR DESCRIPTION
Pull request on the request of Wyclif Lumia.

Have a look at the ForgotPasswordFormControllerTest.java file where I try and execute the tests. The test fails and the error is:

<b>Failed tests: shouldNotNotFailOnNotFoundUsernameTEST(org.openmrs.web.controller.ForgotPasswordFormControllerTest): expected:<[check]> but was:<[What is your grandfather's home town?]</b>?


This means that the user is not being detected and a secret question is being randomly assigned. However, "bruno" is there in the test data. How do I overcome this?