### PR TITLE
Final fix with tests for LUI-45 [Forgot Password Form Leaks Valid Usernames]

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/ForgotPasswordFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/ForgotPasswordFormController.java
@@ -9,8 +9,11 @@
  */
 package org.openmrs.web.controller;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.ServletException;
@@ -18,9 +21,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.commons.lang.StringUtils;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.PrivilegeConstants;
@@ -68,7 +71,7 @@ public class ForgotPasswordFormController extends SimpleFormController {
 	 *      org.springframework.validation.BindException)
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
-	        BindException errors) throws Exception {
+	                                BindException errors) throws Exception {
 		
 		HttpSession httpSession = request.getSession();
 		
@@ -119,22 +122,26 @@ public class ForgotPasswordFormController extends SimpleFormController {
 					if (username != null && username.length() > 0) {
 						user = Context.getUserService().getUserByUsername(username);
 					}
-				}
-				finally {
+				} finally {
 					Context.removeProxyPrivilege(PrivilegeConstants.GET_USERS);
 				}
 				
-				if (user == null /*|| StringUtils.isEmpty(user.getSecretQuestion())*/) {
-					httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.question.empty");
-				} else {
+				if (user == null) {
 					httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.question.fill");
-					//request.setAttribute("secretQuestion", user.getSecretQuestion());
-					
-					// reset the forgotPasswordAttempts because they have a right user.
-					// they will now have 5 more chances to get the question right
-					forgotPasswordAttempts = 0;
+					request.setAttribute("secretQuestion", getRandomFakeSecretQuestion(username));
+				} else {
+					String secretQuestion = Context.getUserService().getSecretQuestion(user);
+					if (secretQuestion == null || secretQuestion.equals("")) {
+						httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.question.empty");
+					} else {
+						httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.question.fill");
+						request.setAttribute("secretQuestion", secretQuestion);
+						
+						// reset the forgotPasswordAttempts because they have a right user.
+						// they will now have 5 more chances to get the question right
+						forgotPasswordAttempts = 0;
+					}
 				}
-				
 			} else {
 				// if they've filled in the username and entered their secret answer
 				
@@ -143,45 +150,79 @@ public class ForgotPasswordFormController extends SimpleFormController {
 				try {
 					Context.addProxyPrivilege(PrivilegeConstants.GET_USERS);
 					user = Context.getUserService().getUserByUsername(username);
-				}
-				finally {
+				} finally {
 					Context.removeProxyPrivilege(PrivilegeConstants.GET_USERS);
 				}
 				
 				// check the secret question again in case the user got here "illegally"
-				if (user == null /*|| StringUtils.isEmpty(user.getSecretQuestion())*/) {
-					httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.question.empty");
-				} else if (/*user.getSecretQuestion() != null &&*/ Context.getUserService().isSecretAnswer(user, secretAnswer)) {
-					
-					StringBuilder randomPassword = new StringBuilder();
-					for (int i = 0; i < 8; i++) {
-						randomPassword.append(String.valueOf((Math.random() * (127 - 48) + 48)));
-					}
-					
-					try {
-						Context.addProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
-						//Context.getUserService().changePassword(user, randomPassword.toString());
-					}
-					finally {
-						Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
-					}
-					
-					httpSession.setAttribute("resetPassword", randomPassword);
-					httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.password.reset");
-					Context.authenticate(username, randomPassword.toString());
-					httpSession.setAttribute("loginAttempts", 0);
-					return new ModelAndView(new RedirectView(request.getContextPath() + "/options.form#Change Login Info"));
-				} else {
+				if (user == null) {
 					httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.answer.invalid");
 					httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.question.fill");
-					//request.setAttribute("secretQuestion", user.getSecretQuestion());
+					request.setAttribute("secretQuestion", getRandomFakeSecretQuestion(username));
+				} else {
+					String secretQuestion = Context.getUserService().getSecretQuestion(user);
+					if (secretQuestion == null || secretQuestion.equals("")) {
+						httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.question.empty");
+					} else if (secretQuestion != null && Context.getUserService().isSecretAnswer(user, secretAnswer)) {
+						
+						String randomPassword = getRandomPassword();
+						
+						try {
+							Context.addProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
+							Context.getUserService().changePassword(user, randomPassword);
+						} finally {
+							Context.removeProxyPrivilege(PrivilegeConstants.EDIT_USER_PASSWORDS);
+						}
+						
+						httpSession.setAttribute("resetPassword", randomPassword);
+						httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.password.reset");
+						Context.authenticate(username, randomPassword);
+						httpSession.setAttribute("loginAttempts", 0);
+						
+						return new ModelAndView(new RedirectView(request.getContextPath() + "/options.form#Change Login Info"));
+					} else {
+						httpSession.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "auth.answer.invalid");
+						httpSession.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "auth.question.fill");
+						request.setAttribute("secretQuestion", secretQuestion);
+					}
 				}
 			}
 		}
 		
 		loginAttemptsByIP.put(ipAddress, forgotPasswordAttempts);
+		
 		request.setAttribute("uname", username);
+		
 		return showForm(request, response, errors);
 	}
 	
+	public String getRandomPassword() {
+		
+		String randomString = RandomStringUtils.randomAlphabetic(1).toUpperCase() + RandomStringUtils.randomAlphanumeric(8)+ RandomStringUtils.randomNumeric(1);
+		return randomString;
+	}
+	
+	public String getRandomFakeSecretQuestion(String username) {
+		
+		List<String> questions = new ArrayList<String>();
+		
+		questions.add(Context.getMessageSourceService().getMessage("What is your best friend's name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your grandfather's home town?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your mother's maiden name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your favorite band?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your first pet's name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your brother's middle name?"));
+		questions.add(Context.getMessageSourceService().getMessage("Which city were you born in?"));
+		
+		int hashValueForName = username.hashCode();
+		
+		//Converting this value to something between 0 and 6
+		if (hashValueForName < 0) {
+			hashValueForName *= -1;
+		}
+		hashValueForName %= 7;
+		
+		//Return random question
+		return questions.get(hashValueForName);
+	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
@@ -1,0 +1,268 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.controller;
+
+
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.openmrs.api.context.Context;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+
+
+/**
+ * Test the different aspects of
+ * {@link org.openmrs.web.controller.ForgotPasswordFormController}
+ */
+
+public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensitiveTest {
+	
+	protected static final String TEST_DATA = "org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml";
+	
+	@Before
+	public void runBeforeEachTest() throws Exception {
+		executeDataSet(TEST_DATA);
+		Context.logout();
+	}
+	
+	/**
+	 * Check to see if the admin's secret question comes back
+	 *
+	 * @throws Exception
+	 */
+	
+	@Test
+	public void shouldNotNotFailOnNotFoundUsername() throws Exception {
+		
+		ForgotPasswordFormController controller = new ForgotPasswordFormController();
+		
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		
+		request.setParameter("uname", "validuser");
+		request.setMethod("POST");
+		
+		controller.handleRequest(request, response);
+		
+		Assert.assertEquals("validuser", request.getAttribute("uname"));
+		Assert.assertEquals("valid secret question", request.getAttribute("secretQuestion"));
+	}
+	
+	
+	@Test
+	public void shouldAuthenticateAsUserWithValidSecretQuestion() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		
+		HttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		
+		Assert.assertEquals(2, Context.getAuthenticatedUser().getId().intValue());
+	}
+	
+	/**
+	 * If a user enters the wrong secret answer, they should be kicked back to the form and not be
+	 * authenticated
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldNotAuthenticateAsUserWithInvalidSecretQuestion() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "invaliduser");
+		request.addParameter("secretAnswer", "invalid secret answer");
+		
+		HttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 5 requests, the 6th should fail even if that one has a valid username in it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldLockOutAfterFiveFailedInvalidUsernames() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		Assert.assertNull(request.getAttribute("secretQuestion"));
+	}
+	
+	/**
+	 * If a user enters 5 requests, the 6th should fail even if that one has a valid username and a
+	 * secret answer associated with it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldNotAuthenticateAfterFiveFailedInvalidUsernames() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 5 requests with username+secret answer, the 6th should fail even if that one
+	 * has a valid answer in it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldLockOutAfterFiveFailedInvalidSecretAnswers() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "validuser");
+			request.addParameter("secretAnswer", "invalid secret answer");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 4 username requests, the 5th one should reset the lockout and they should be
+	 * allowed 5 attempts at the secret answer
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldGiveUserFiveSecretAnswerAttemptsAfterLessThanFiveFailedUsernameAttempts() throws Exception {
+		ForgotPasswordFormController controller = new ForgotPasswordFormController();
+		
+		for (int x = 1; x <= 4; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first four, now the fifth is a valid username
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertNotNull(request.getAttribute("secretQuestion"));
+		
+		// now the user has 5 chances at the secret answer
+		
+		// fifth request
+		MockHttpServletRequest request5 = new MockHttpServletRequest();
+		request5.setMethod("POST");
+		
+		request5.addParameter("uname", "validuser");
+		request5.addParameter("secretAnswer", "invalid answer");
+		controller.handleRequest(request5, new MockHttpServletResponse());
+		Assert.assertNotNull(request5.getAttribute("secretQuestion"));
+		
+		// sixth request (should not lock out because is after valid username)
+		MockHttpServletRequest request6 = new MockHttpServletRequest();
+		request6.setMethod("POST");
+		
+		request6.addParameter("uname", "validuser");
+		request6.addParameter("secretAnswer", "invalid answer");
+		request.setMethod("POST");
+		controller.handleRequest(request6, new MockHttpServletResponse());
+		Assert.assertNotNull(request6.getAttribute("secretQuestion"));
+		
+		// seventh request (should authenticate with valid answer)
+		MockHttpServletRequest request7 = new MockHttpServletRequest();
+		request7.setMethod("POST");
+		
+		request7.addParameter("uname", "validuser");
+		request7.addParameter("secretAnswer", "valid secret answer");
+		controller.handleRequest(request7, new MockHttpServletResponse());
+		
+		Assert.assertTrue(Context.isAuthenticated());
+	}
+	
+	@Test
+	public void shouldNotAuthenticateWithInvalidSecretQuestionIfUserIsNull() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		
+		request.setMethod("POST");
+		request.addParameter("uname", "");
+		HttpServletResponse response = new MockHttpServletResponse();
+		
+		controller.handleRequest(request, response);
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+}

--- a/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
+++ b/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+
+    <person person_id="2" gender="M" birthdate="1975-06-30" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" changed_by="1" date_changed="2007-09-20 21:54:12.0" voided="false" void_reason="" uuid="ebb83b24-4525-4f04-a81a-c79ab162b4d7"/>
+    <users user_id="2" person_id="2" system_id="2-7" username="validuser" password="4a1750c8607dfa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f" secret_question="valid secret question" secret_answer="8912c44133c953ced5489ae7bc4b2318da35eeb2dd19b5aee33c37d0b64c8e5ba9ac29051cd9de130bbd02ade9f1c296841761a3de82d4b694517d6d5be6dd3b" creator="1" date_created="2005-01-01 00:00:00.0" changed_by="1" date_changed="2007-09-20 21:54:12.0" retired="false" retire_reason="" uuid="74f96712-e6d3-11de-8404-001e378eb67e"/>
+
+</dataset>


### PR DESCRIPTION
This is the Final Fix for the Leakage of Usernames that was occurring when a user clicked on the 'forgotPassword' link. 

https://issues.openmrs.org/browse/LUI-45

**The Issue**: Whenever a hacker enters the name of a random user, and the user is valid, his/her secret question is shown. This is a major vulnerability that had to be addressed.

**The Fix:** The solution is to ask ANY user a secret question. If the user is invalid, a random Fake Secret Question is asked whose answer is always false and will not the user pass, locking him out after 5 tries. This secret question is assigned on the basis of the hashvalue of the entered username.