### PR TITLE
FINAL fix addressing security issues in LUI-45 [Forgot Password Form Leaks Valid Usernames]

### DIFF
--- a/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
@@ -1,0 +1,282 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.controller;
+
+
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.openmrs.api.context.Context;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Test the different aspects of
+ * {@link org.openmrs.web.controller.ForgotPasswordFormController}
+ */
+
+public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensitiveTest {
+	
+	protected static final String TEST_DATA = "org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml";
+	
+	@Before
+	public void runBeforeEachTest() throws Exception {
+		executeDataSet(TEST_DATA);
+		Context.logout();
+	}
+	
+	/**
+	 * Check to see if the admin's secret question comes back
+	 *
+	 * @throws Exception
+	 */
+	
+	@Test
+	public void shouldNotFailOnInvalidUsername() throws Exception {
+		
+		ForgotPasswordFormController controller = new ForgotPasswordFormController();
+		
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		
+		request.setParameter("uname", "invaliduser");
+		request.setMethod("POST");
+		
+		controller.handleRequest(request, response);
+		
+		Assert.assertEquals("invaliduser", request.getAttribute("uname"));
+		
+		List<String> questions = new ArrayList<String>();
+		
+		questions.add(Context.getMessageSourceService().getMessage("What is your best friend's name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your grandfather's home town?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your mother's maiden name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your favorite band?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your first pet's name?"));
+		questions.add(Context.getMessageSourceService().getMessage("What is your brother's middle name?"));
+		questions.add(Context.getMessageSourceService().getMessage("Which city were you born in?"));
+		
+		//Check that one of the fake questions is assigned to the invalid username
+		Assert.assertTrue(questions.contains(request.getAttribute("secretQuestion")));
+	}
+	
+	
+	@Test
+	public void shouldAcceptAsUserWithValidSecretQuestion() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		
+		HttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		
+		Assert.assertEquals(2, Context.getAuthenticatedUser().getId().intValue());
+	}
+	
+	/**
+	 * If a user enters the wrong secret answer, they should be kicked back to the form and not be
+	 * Acceptd
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldNotAcceptAsUserWithInvalidSecretQuestion() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "invaliduser");
+		request.addParameter("secretAnswer", "invalid secret answer");
+		
+		HttpServletResponse response = new MockHttpServletResponse();
+		controller.handleRequest(request, response);
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 5 requests, the 6th should fail even if that one has a valid username in it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldLockOutAfterFiveFailedInvalidUsernames() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		Assert.assertNull(request.getAttribute("secretQuestion"));
+	}
+	
+	/**
+	 * If a user enters 5 requests, the 6th should fail even if that one has a valid username and a
+	 * secret answer associated with it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldNotAcceptAfterFiveFailedInvalidUsernames() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 5 requests with username+secret answer, the 6th should fail even if that one
+	 * has a valid answer in it
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldLockOutAfterFiveFailedInvalidSecretAnswers() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		
+		for (int x = 1; x <= 5; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "validuser");
+			request.addParameter("secretAnswer", "invalid secret answer");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first five, now the sixth request (with a valid user) should fail
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		request.addParameter("secretAnswer", "valid secret answer");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+	
+	/**
+	 * If a user enters 4 username requests, the 5th one should reset the lockout and they should be
+	 * allowed 5 attempts at the secret answer
+	 *
+	 * @throws Exception
+	 */
+	@Test
+	public void shouldGiveUserFiveSecretAnswerAttemptsAfterLessThanFiveFailedUsernameAttempts() throws Exception {
+		ForgotPasswordFormController controller = new ForgotPasswordFormController();
+		
+		for (int x = 1; x <= 4; x++) {
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			request.setMethod("POST");
+			
+			request.addParameter("uname", "invaliduser");
+			
+			controller.handleRequest(request, new MockHttpServletResponse());
+		}
+		
+		// those were the first four, now the fifth is a valid username
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setMethod("POST");
+		
+		request.addParameter("uname", "validuser");
+		
+		controller.handleRequest(request, new MockHttpServletResponse());
+		
+		Assert.assertNotNull(request.getAttribute("secretQuestion"));
+		
+		// now the user has 5 chances at the secret answer
+		
+		// fifth request
+		MockHttpServletRequest request5 = new MockHttpServletRequest();
+		request5.setMethod("POST");
+		
+		request5.addParameter("uname", "validuser");
+		request5.addParameter("secretAnswer", "invalid answer");
+		controller.handleRequest(request5, new MockHttpServletResponse());
+		Assert.assertNotNull(request5.getAttribute("secretQuestion"));
+		
+		// sixth request (should not lock out because is after valid username)
+		MockHttpServletRequest request6 = new MockHttpServletRequest();
+		request6.setMethod("POST");
+		
+		request6.addParameter("uname", "validuser");
+		request6.addParameter("secretAnswer", "invalid answer");
+		request.setMethod("POST");
+		controller.handleRequest(request6, new MockHttpServletResponse());
+		Assert.assertNotNull(request6.getAttribute("secretQuestion"));
+		
+		// seventh request (should Accept with valid answer)
+		MockHttpServletRequest request7 = new MockHttpServletRequest();
+		request7.setMethod("POST");
+		
+		request7.addParameter("uname", "validuser");
+		request7.addParameter("secretAnswer", "valid secret answer");
+		controller.handleRequest(request7, new MockHttpServletResponse());
+		
+		Assert.assertTrue(Context.isAuthenticated());
+	}
+	
+	@Test
+	public void shouldNotAcceptWithInvalidSecretQuestionIfUserIsNull() throws Exception {
+		ForgotPasswordFormController controller = (ForgotPasswordFormController) applicationContext.getBean("forgotPasswordForm");
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		
+		request.setMethod("POST");
+		request.addParameter("uname", "");
+		HttpServletResponse response = new MockHttpServletResponse();
+		
+		controller.handleRequest(request, response);
+		Assert.assertFalse(Context.isAuthenticated());
+	}
+}

--- a/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
+++ b/omod/src/test/resources/org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+
+    <person person_id="2" gender="M" birthdate="1975-06-30" dead="false" creator="1" date_created="2005-01-01 00:00:00.0" changed_by="1" date_changed="2007-09-20 21:54:12.0" voided="false" void_reason="" uuid="ebb83b24-4525-4f04-a81a-c79ab162b4d7"/>
+    <users user_id="2" person_id="2" system_id="2-7" username="validuser" password="4a1750c8607dfa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f" secret_question="valid secret question" secret_answer="8912c44133c953ced5489ae7bc4b2318da35eeb2dd19b5aee33c37d0b64c8e5ba9ac29051cd9de130bbd02ade9f1c296841761a3de82d4b694517d6d5be6dd3b" creator="1" date_created="2005-01-01 00:00:00.0" changed_by="1" date_changed="2007-09-20 21:54:12.0" retired="false" retire_reason="" uuid="74f96712-e6d3-11de-8404-001e378eb67e"/>
+
+</dataset>


### PR DESCRIPTION
This is the Final Fix for the Leakage of Usernames that was occurring when a user clicked on the 'forgotPassword' link. 

https://issues.openmrs.org/browse/LUI-45
<br>
**In light of recent comments on the ticket, it has come to notice that this is a serious security issue and must be resolved ASAP. If you see the comments, you will notice that this code fixes the issue as per ticket description and quite well in general.**
<br>
**The Issue**: Whenever a hacker enters the name of a random user, and the user is valid, his/her secret question is shown. This is a major vulnerability that had to be addressed.

**The Fix:** The solution is to ask ANY user a secret question. If the user is invalid, a random Fake Secret Question is asked whose answer is always false and will not the user pass, locking him out after 5 tries. This secret question is assigned on the basis of the hashvalue of the entered username.

**basically, the hacker will never know if the user exists because a question is asked irrespective of whether a user is present and invalid users are never authenticated and locked out after 5 tries**