### PR TITLE
RAD-151 radiolgyOrderForm looses Orderer on error

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -220,6 +220,7 @@
 				<param name="class" value="org.openmrs.web.dwr.DWRProviderService" />
 				<include method="findProviderCountAndProvider"/>
 				<include method="findProvider"/>
+      			<include method="getProvider"/>
 			</create>
 
             <create creator="new" javascript="DWRProgramWorkflowService">

--- a/omod/src/main/webapp/tags/providerField.tag
+++ b/omod/src/main/webapp/tags/providerField.tag
@@ -44,8 +44,8 @@
 		<c:if test="${not empty initialValue}">
 			jquerySelectEscaped("${formFieldId}").val("${initialValue}");
 			DWRProviderService.getProvider("${initialValue}", function(provider) {
-				jquerySelectEscaped("${displayNameInputId}").val(provider.name);
-				jquerySelectEscaped("${displayNameInputId}").autocomplete("option", "initialValue", provider.name);
+				jquerySelectEscaped("${displayNameInputId}").val(provider.displayName);
+				jquerySelectEscaped("${displayNameInputId}").autocomplete("option", "initialValue", provider.displayName);
 				<c:if test="${not empty callback}">
 					${callback}("${formFieldName}", provider);
 			</c:if>


### PR DESCRIPTION
Orderer input field no longer loses data after form error messages. The Oderer is now populated with the data the user had previously typed before clicking "Save Order".
Changed provider.name to provider.displayName in providerField.tag. Additionally added the getProvider method for DWRProviderService in the config.xml file

![1](https://cloud.githubusercontent.com/assets/3146497/15001716/92391b8e-115f-11e6-9973-9a6c047e3122.png)

![2](https://cloud.githubusercontent.com/assets/3146497/15001719/9682b4b6-115f-11e6-86e0-5995ecb8e4be.png)

![3](https://cloud.githubusercontent.com/assets/3146497/15001723/98ed9cac-115f-11e6-9134-f1890fa0b744.png)

![4](https://cloud.githubusercontent.com/assets/3146497/15001724/9bfbe610-115f-11e6-80c4-e986a864ddf7.png)

![5](https://cloud.githubusercontent.com/assets/3146497/15001728/9e672c5c-115f-11e6-8dd5-a750a4b69d98.png)

![6](https://cloud.githubusercontent.com/assets/3146497/15001732/a1664af0-115f-11e6-8d38-3ddf60b7c135.png)
