### PR TITLE
Add RegexValidatedTextDatatypeHandler

### DIFF
--- a/omod/src/main/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandler.java
+++ b/omod/src/main/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandler.java
@@ -1,0 +1,90 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.attribute.handler;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.customdatatype.CustomDatatype;
+import org.openmrs.customdatatype.InvalidCustomValueException;
+import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
+import org.springframework.stereotype.Component;
+
+/**
+ * A handler for the {@link RegexValidatedTextDatatype}.
+ */
+@Component
+public class RegexValidatedTextDatatypeHandler implements FieldGenDatatypeHandler<RegexValidatedTextDatatype, java.lang.String> {
+	
+	
+	private static final Log log = LogFactory.getLog(RegexValidatedTextDatatypeHandler.class);
+	
+	/**
+	 * @see org.openmrs.customdatatype.CustomDatatypeHandler#setHandlerConfiguration(String)
+	 */
+	@Override
+	public void setHandlerConfiguration(String arg0) {
+		// not used
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getWidgetName()
+	 */
+	@Override
+	public String getWidgetName() {
+		return "java.lang.String";
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getWidgetConfiguration()
+	 */
+	@Override
+	public Map<String, Object> getWidgetConfiguration() {
+		return null;
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getValue(CustomDatatype,
+	 *      HttpServletRequest, String)
+	 */
+	@Override
+	public String getValue(RegexValidatedTextDatatype datatype, HttpServletRequest request, String formFieldName)
+	        throws InvalidCustomValueException {
+		String stringVal = request.getParameter(formFieldName);
+		try {
+			datatype.validate(stringVal);
+		}
+		catch (InvalidCustomValueException ex) {
+			throw new InvalidCustomValueException("Invalid value: " + stringVal);
+		}
+		return stringVal;
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.HtmlDisplayableDatatypeHandler#toHtmlSummary(CustomDatatype,
+	 *      String)
+	 */
+	@Override
+	public CustomDatatype.Summary toHtmlSummary(CustomDatatype<String> datatype, String valueReference) {
+		return new CustomDatatype.Summary(toHtml(datatype, valueReference), true);
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.HtmlDisplayableDatatypeHandler#toHtml(CustomDatatype,
+	 *      String)
+	 */
+	@Override
+	public String toHtml(CustomDatatype<String> datatype, String valueReference) {
+		return valueReference;
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
@@ -1,0 +1,118 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.attribute.handler;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.openmrs.customdatatype.CustomDatatype;
+import org.openmrs.customdatatype.InvalidCustomValueException;
+import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Tests {@code RegexValidatedTextDatatypeHandler}.
+ */
+@RunWith(PowerMockRunner.class)
+public class RegexValidatedTextDatatypeHandlerTest {
+	
+	
+	@Rule
+	ExpectedException expectedException = ExpectedException.none();
+	
+	private RegexValidatedTextDatatypeHandler handler = new RegexValidatedTextDatatypeHandler();
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getValue(CustomDatatype,
+	 *      HttpServletRequest, String)
+	 * @verifies return attribute value from request for given field name if the attribute value is
+	 *           valid according to datataype
+	 */
+	@Test
+	public void getValue_shouldReturnAttributeValueFromRequestForGivenFieldNameIfTheAttributeValueIsValidAccordingToDatatype() {
+		
+		// given
+		String fieldName = "regexfield";
+		String validFieldValue = "1";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(fieldName, validFieldValue);
+		RegexValidatedTextDatatype datatype = new RegexValidatedTextDatatype();
+		datatype.setConfiguration("^[012]$");
+		
+		assertThat(handler.getValue(datatype, request, fieldName), is(validFieldValue));
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getValue(CustomDatatype,
+	 *      HttpServletRequest, String)
+	 * @verifies throw invalid custom value exception if attribute value from request for given
+	 *           field name is invalid according to datatype
+	 */
+	@Test
+	public void getValue_shouldThrowInvalidCustomValueExceptionIfAttributeValueFromRequestForGivenFieldNameIsInvalidAccordingToDatatype() {
+		
+		// given
+		String fieldName = "regexfield";
+		String invalidFieldValue = "9";
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter(fieldName, invalidFieldValue);
+		RegexValidatedTextDatatype datatype = new RegexValidatedTextDatatype();
+		datatype.setConfiguration("^[012]$");
+		
+		expectedException.expect(InvalidCustomValueException.class);
+		expectedException.expectMessage("Invalid value: " + invalidFieldValue);
+		handler.getValue(datatype, request, fieldName);
+	}
+	
+	/**
+	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#toHtml(org.openmrs.customdatatype.CustomDatatype,
+	 *      String)
+	 * @verifies return the value reference
+	 */
+	@Test
+	public void toHtml_shouldReturnTheValueReference() throws Exception {
+		
+		final String fieldValue = "1";
+		
+		RegexValidatedTextDatatype datatype = new RegexValidatedTextDatatype();
+		datatype.setConfiguration("^[012]$");
+		
+		assertThat(handler.toHtml(datatype, fieldValue), is(fieldValue));
+	}
+	
+	/**
+	 * @verifies use the name in the html summary instance
+	 * @see BaseMetadataFieldGenDatatypeHandler#toHtmlSummary(org.openmrs.customdatatype.CustomDatatype,
+	 *      String)
+	 */
+	@Test
+	public void toHtmlSummary_shouldUseTheNameInTheHtmlSummaryInstance() throws Exception {
+		
+		final String fieldValue = "1";
+		
+		RegexValidatedTextDatatype datatype = new RegexValidatedTextDatatype();
+		datatype.setConfiguration("^[012]$");
+		
+		CustomDatatype.Summary summary = handler.toHtmlSummary(datatype, fieldValue);
+		
+		assertNotNull(summary);
+		assertEquals(fieldValue, summary.getSummary());
+		assertEquals(true, summary.isComplete());
+	}
+}


### PR DESCRIPTION
RegexValidatedTextDatatype is not validated for when setting a global property
datatype to it since now handler exists. This prevents using regex for
validation of global properties.

* added RegexValidatedTextDatatypeHandler with tests

see https://issues.openmrs.org/browse/LUI-81