### PR TITLE
TRUNK-4846: Search by ID displays double results

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
@@ -93,6 +93,7 @@ public class DWRConceptService {
 	 * @should not return concept by given id if datatype is not included
 	 * @should not return concept by given id if datatype is excluded
 	 * @should include
+	 * @should not return duplicates when searching by concept id
 	 * @since 1.8
 	 */
 	public List<Object> findBatchOfConcepts(String phrase, boolean includeRetired, List<String> includeClassNames,
@@ -134,7 +135,7 @@ public class DWRConceptService {
 		
 		try {
 			ConceptService cs = Context.getConceptService();
-			List<ConceptSearchResult> searchResults = new ArrayList<ConceptSearchResult>();
+			Set<ConceptSearchResult> searchResults = new HashSet<ConceptSearchResult>();
 			
 			if (phrase.matches("\\d+")) {
 				// user searched on a number. Insert concept with

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRConceptServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRConceptServiceTest.java
@@ -274,4 +274,15 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		}
 		
 	}
+	
+	@Test
+	public void findBatchOfConcepts_shouldNotReturnDuplicatesWhenSearchingByConceptId() {
+		String phrase = "1001";
+		Concept expected = Context.getConceptService().getConcept(phrase);
+		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase,
+				Boolean.FALSE, null, null, null, null, null, null);
+		Assert.assertNotNull(result);
+		Assert.assertEquals(1, result.size());
+		Assert.assertTrue(isConceptFound(expected, result));
+	}
 }

--- a/omod/src/test/resources/org/openmrs/web/dwr/include/DWRConceptServiceTest-coded-concept-with-no-answers.xml
+++ b/omod/src/test/resources/org/openmrs/web/dwr/include/DWRConceptServiceTest-coded-concept-with-no-answers.xml
@@ -13,5 +13,11 @@
 <dataset>
   <concept concept_id="1000" retired="false" datatype_id="2" class_id="7" is_set="false" creator="1" date_created="2005-01-01 00:00:00.0" uuid="957eba27-2b38-43e8-91a9-4dfe3956a32d"/>
   <concept_description concept_description_id="1000" concept_id="1000" description="this is a description" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" uuid="0a6f34ea-043a-4e69-b418-1d7bb66b99b6"/>
-  <concept_name concept_id="1000" name="Some coded concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="1" concept_name_type="FULLY_SPECIFIED" locale_preferred="0" voided="false" uuid="8edfd54f-b189-43dd-86e0-913591978e48"/>
+  <concept_name concept_id="1000" name="Some coded concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="1" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="8edfd54f-b189-43dd-86e0-913591978e48"/>
+
+  <concept concept_id="1001" retired="false" datatype_id="2" class_id="7" is_set="false" creator="1" date_created="2005-01-01 00:00:00.0" uuid="de1104fe-4074-11e6-94a2-34e6d77c15d6"/>
+  <concept_description concept_description_id="1001" concept_id="1001" description="this is a description" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" uuid="c73820d7-4077-11e6-94a2-34e6d77c15d6"/>
+  <concept_name concept_id="1001" name="Some other coded concept name" locale="en" creator="1" date_created="2005-01-01 00:00:00.0" concept_name_id="2" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="ed729dad-4077-11e6-94a2-34e6d77c15d6"/>
+  <concept_reference_term concept_reference_term_id="1" concept_source_id="1" code="1001" name="no term name3" description="" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="6e81ca8d-842a-4748-b92c-607acc6d5e6a"/>
+  <concept_reference_map concept_map_id="1" concept_id="1001" concept_reference_term_id="1" concept_map_type_id="6" creator="1" date_created="2004-08-12 00:00:00.0" uuid="25a54a60-157a-448d-bc17-62210572bfa8"/>
 </dataset>


### PR DESCRIPTION
Changed the data structure that holds Concept Results from `List` to `Set` since `Set` only allows for unique results.