### PR TITLE
LUI-95 errorhandler.jsp cannot find openmrs taglib

### DIFF
--- a/omod/src/main/webapp/errorhandler.jsp
+++ b/omod/src/main/webapp/errorhandler.jsp
@@ -1,6 +1,6 @@
 <%@ page isErrorPage="true" import="java.io.*" %>
 
-<%@ taglib uri="/openmrs" prefix="openmrs" %>
+<%@ taglib uri="/WEB-INF/taglibs/openmrs.tld" prefix="openmrs" %>
 <%-- 
 	Exceptions thrown from within jsps e.g those with scripts calling code that requires authentication, are
 	forwarded here so we need to be able to handle them too, but by the time we are on this JSP, the actual  


### PR DESCRIPTION
On error in a jsp file the errorhandler page should nicely handle exceptions
for better user experience, however the taglib include was pointing to the
older path when the legacy ui was still part of the core.

* changed taglib uri to same value as in the (omod/src/main/webapp/template/include.jsp)

see https://issues.openmrs.org/browse/LUI-95