### PR TITLE
LUI-86 Show findpatient nav link only with privilege

### DIFF
--- a/omod/src/main/webapp/template/gutter.jsp
+++ b/omod/src/main/webapp/template/gutter.jsp
@@ -6,6 +6,7 @@
 		<a href="${pageContext.request.contextPath}/"><openmrs:message code="Navigation.home"/></a>
 	</li>
 
+	<openmrs:hasPrivilege privilege="View Patients">
 	<li id="findPatientNavLink">
 		<a href="${pageContext.request.contextPath}/findPatient.htm">
 			<openmrs:hasPrivilege privilege="Add Patients">
@@ -16,7 +17,8 @@
 			</openmrs:hasPrivilege>
 		</a>
 	</li>
-	
+	</openmrs:hasPrivilege>
+
 	<openmrs:hasPrivilege privilege="View Concepts">
 		<li id="dictionaryNavLink">
 			<a href="${pageContext.request.contextPath}/dictionary/index.htm"><openmrs:message code="Navigation.dictionary"/></a>


### PR DESCRIPTION
"Find Patient" navigation bar/link shows for users that do not have the "View
Patients" privilege. When clicking on it the user just gets redirected to a
page telling him he does not have the privilege to access the page.

* Wrap "Find/Create Patient" navigation bar/link with hasPrivilege
"View Patients" to prevent showing "Find Patient" to a user that doesnt have
the privilege.

see https://issues.openmrs.org/browse/LUI-86