### PR TITLE
LUI-96 Add github PR integration for test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ matrix:
 branches:
   only:
     - master
+after_success:
+  - mvn jacoco:report coveralls:report
 notifications:
   email: false
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # openmrs-module-legacyui
-[![Build Status](https://travis-ci.org/openmrs/openmrs-module-legacyui.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-module-legacyui)
+[![Build Status](https://travis-ci.org/openmrs/openmrs-module-legacyui.svg?branch=master)](https://travis-ci.org/openmrs/openmrs-module-legacyui) [![Coverage Status](https://coveralls.io/repos/github/openmrs/openmrs-module-legacyui/badge.svg?branch=master)](https://coveralls.io/github/openmrs/openmrs-module-legacyui?branch=master)
 
 - The legacy user interface for OpenMRS Platform 2.x is chiefly comprised of administrative functions and the patient dashboard. 
 - A new and more contemporary UI has been introduced via a UI framework and the legacy UI is kept around for 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -243,6 +243,15 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<configuration>
+					<includes>
+						<include>org/openmrs/**</include>
+					</includes>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,24 @@
 						</execution>
 					</executions>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.7.7.201606060606</version>
+					<executions>
+						<execution>
+							<id>prepare-agent</id>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.eluder.coveralls</groupId>
+					<artifactId>coveralls-maven-plugin</artifactId>
+					<version>4.2.0</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>


### PR DESCRIPTION
* add jacoco maven plugin for generating coverage reports
* add coveralls maven plugin to send jacoco reports to coveralls.io
* add travis after_success command to send jacoco reports to coveralls.io after
successful builds
* jacoco and coverals are configured in root pom pluginmanagement
* jacoco only generates coverage for omod/ for now since there are no tests in
api/

see https://issues.openmrs.org/browse/LUI-96

TRY:
you can locally get the coverage report with:

```
mvn clean install jacoco:report
```
should run tests, prepare jacoco and generate omod/target/site/jacoco
with an index.html where you can see the unit test coverage report.

TODO:
hopefully after the first run on travis CI the project will show up at:
https://coveralls.io/github/openmrs/openmrs-module-legacyui

the maven coveralls plugin states that if using travis CI no further config is needed:
https://github.com/trautonen/coveralls-maven-plugin#configuration

unfortunately I cant remember if I had to add the project on coveralls for the radiology module. see https://coveralls.io/github/openmrs/openmrs-module-radiology?branch=master

final TODO, add the badge to this repo ;)
this needs to be shown, since this repo misses loooots of tests! :fearful: 

