### PR TITLE
LUI-100 Privilege "Edit Concepts" does not exist

### DIFF
--- a/omod/src/main/webapp/admin/concepts/conceptDrugForm.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptDrugForm.jsp
@@ -1,6 +1,6 @@
 <%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp" %>
 
-<openmrs:require privilege="Edit Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptDrug.form" />
+<openmrs:require privilege="Manage Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptDrug.form" />
 
 <%@ include file="/WEB-INF/view/module/legacyui/template/header.jsp" %>
 <%@ include file="localHeader.jsp" %>

--- a/omod/src/main/webapp/admin/concepts/conceptDrugList.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptDrugList.jsp
@@ -1,6 +1,6 @@
 <%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp"%>
 
-<openmrs:require privilege="Edit Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptDrug.list" />
+<openmrs:require privilege="Manage Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptDrug.list" />
 
 <%@ include file="/WEB-INF/view/module/legacyui/template/header.jsp"%>
 <%@ include file="localHeader.jsp"%>

--- a/omod/src/main/webapp/admin/concepts/conceptProposalForm.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptProposalForm.jsp
@@ -1,6 +1,6 @@
 <%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp" %>
 
-<openmrs:require privilege="Edit Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptProposal.form" />
+<openmrs:require privilege="Manage Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptProposal.form" />
 
 <%@ include file="/WEB-INF/view/module/legacyui/template/header.jsp" %>
 <%@ include file="localHeader.jsp" %>

--- a/omod/src/main/webapp/admin/concepts/conceptProposalList.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptProposalList.jsp
@@ -45,7 +45,7 @@
 
 <br/><br/>
 
-<openmrs:hasPrivilege privilege="Edit Concepts">
+<openmrs:hasPrivilege privilege="Manage Concepts">
 	<table>
 		<tr>
 			<th><openmrs:message code="ConceptProposal.includeCompleted"/></th>

--- a/omod/src/main/webapp/admin/concepts/conceptSetDerivedForm.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptSetDerivedForm.jsp
@@ -1,6 +1,6 @@
 <%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp" %>
 
-<openmrs:require privilege="Edit Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptSetDerived.form" />
+<openmrs:require privilege="Manage Concepts" otherwise="/login.htm" redirect="/admin/concepts/conceptSetDerived.form" />
 
 <%@ include file="/WEB-INF/view/module/legacyui/template/header.jsp" %>
 <%@ include file="localHeader.jsp" %>

--- a/omod/src/main/webapp/admin/dictionary/concept.jsp
+++ b/omod/src/main/webapp/admin/dictionary/concept.jsp
@@ -356,7 +356,7 @@
 		
 		<tr><td colspan="2"><br/></td></tr>
 		
-		<openmrs:hasPrivilege privilege="Edit Concepts">
+		<openmrs:hasPrivilege privilege="Manage Concepts">
 			<c:if test="${ not empty command.conceptDrugList and fn:length(command.conceptDrugList) > 0}">
 				<tr>
 					<td colspan="2">

--- a/omod/src/main/webapp/admin/dictionary/conceptStatsForm.jsp
+++ b/omod/src/main/webapp/admin/dictionary/conceptStatsForm.jsp
@@ -57,13 +57,13 @@
 		<a href="#previousConcept" id="previousConcept" valign="middle" accesskey="," onclick="return jumpToConcept('previous')"><openmrs:message code="general.previous"/></a>
 			|
 		<a href="concept.htm?conceptId=${concept.conceptId}" id="viewConcept" accesskey="v" ><openmrs:message code="general.view"/></a> |
-		<openmrs:hasPrivilege privilege="Edit Concepts"><a href="concept.form?conceptId=${concept.conceptId}" accesskey="e" id="editConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.edit"/><openmrs:hasPrivilege privilege="Edit Concepts"></a></openmrs:hasPrivilege> |
+		<openmrs:hasPrivilege privilege="Manage Concepts"><a href="concept.form?conceptId=${concept.conceptId}" accesskey="e" id="editConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.edit"/><openmrs:hasPrivilege privilege="Manage Concepts"></a></openmrs:hasPrivilege> |
 		<a href="#nextConcept" id="nextConcept" accesskey="." valign="middle" onclick="return jumpToConcept('next')"><openmrs:message code="general.next"/></a>
 			|
 	</form>
 </c:if>
 
-<openmrs:hasPrivilege privilege="Edit Concepts"><a href="concept.form" id="newConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.new"/><openmrs:hasPrivilege privilege="Edit Concepts"></a></openmrs:hasPrivilege>
+<openmrs:hasPrivilege privilege="Manage Concepts"><a href="concept.form" id="newConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.new"/><openmrs:hasPrivilege privilege="Manage Concepts"></a></openmrs:hasPrivilege>
 
 <openmrs:extensionPoint pointId="org.openmrs.dictionary.conceptFormHeader" type="html" parameters="conceptId=${command.concept.conceptId}" />
 

--- a/omod/src/main/webapp/dictionary/concept.jsp
+++ b/omod/src/main/webapp/dictionary/concept.jsp
@@ -366,7 +366,7 @@
 		
 		<tr><td colspan="2"><br/></td></tr>
 		
-		<openmrs:hasPrivilege privilege="Edit Concepts">
+		<openmrs:hasPrivilege privilege="Manage Concepts">
 			<c:if test="${ not empty command.conceptDrugList and fn:length(command.conceptDrugList) > 0}">
 				<tr>
 					<td colspan="2">

--- a/omod/src/main/webapp/dictionary/conceptStatsForm.jsp
+++ b/omod/src/main/webapp/dictionary/conceptStatsForm.jsp
@@ -57,13 +57,13 @@
 		<a href="#previousConcept" id="previousConcept" valign="middle" accesskey="," onclick="return jumpToConcept('previous')"><openmrs:message code="general.previous"/></a>
 			|
 		<a href="concept.htm?conceptId=${concept.conceptId}" id="viewConcept" accesskey="v" ><openmrs:message code="general.view"/></a> |
-		<openmrs:hasPrivilege privilege="Edit Concepts"><a href="concept.form?conceptId=${concept.conceptId}" accesskey="e" id="editConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.edit"/><openmrs:hasPrivilege privilege="Edit Concepts"></a></openmrs:hasPrivilege> |
+		<openmrs:hasPrivilege privilege="Manage Concepts"><a href="concept.form?conceptId=${concept.conceptId}" accesskey="e" id="editConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.edit"/><openmrs:hasPrivilege privilege="Manage Concepts"></a></openmrs:hasPrivilege> |
 		<a href="#nextConcept" id="nextConcept" accesskey="." valign="middle" onclick="return jumpToConcept('next')"><openmrs:message code="general.next"/></a>
 			|
 	</form>
 </c:if>
 
-<openmrs:hasPrivilege privilege="Edit Concepts"><a href="concept.form" id="newConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.new"/><openmrs:hasPrivilege privilege="Edit Concepts"></a></openmrs:hasPrivilege>
+<openmrs:hasPrivilege privilege="Manage Concepts"><a href="concept.form" id="newConcept" valign="middle"></openmrs:hasPrivilege><openmrs:message code="general.new"/><openmrs:hasPrivilege privilege="Manage Concepts"></a></openmrs:hasPrivilege>
 
 <openmrs:extensionPoint pointId="org.openmrs.dictionary.conceptFormHeader" type="html" parameters="conceptId=${command.concept.conceptId}" />
 


### PR DESCRIPTION
"Edit Concepts" seems to be a very old privilege that has been replaced by
"Manage Concepts" maybe in ~2008 in the openmrs-core.

* replace occurences of "Edit Concepts" in jsp require tags with "Manage Concepts"

this also seems to fix the LUI-97 bug "Cannot create new conceptSource"

see https://issues.openmrs.org/browse/LUI-100