### PR TITLE
LUI-101 conceptReferenceTermForm misses required privilege

### DIFF
--- a/omod/src/main/webapp/admin/concepts/conceptReferenceTermForm.jsp
+++ b/omod/src/main/webapp/admin/concepts/conceptReferenceTermForm.jsp
@@ -1,7 +1,7 @@
 <%@page import="java.util.Locale" %>
 <%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp" %>
 
-<openmrs:require privilege="Manage Concept Reference Terms" otherwise="/login.htm"
+<openmrs:require allPrivileges="Manage Concept Reference Terms,Get Concept Map Types" otherwise="/login.htm"
                  redirect="/admin/concepts/conceptReferenceTerm.form"/>
 
 <%@ include file="/WEB-INF/view/module/legacyui/template/header.jsp" %>


### PR DESCRIPTION
conceptReferenceTermForm.jsp requires only "Manage Concept Reference Terms"
but if accessing the page with a user with that privilege the page doesnt show
the actual form to enter/see existing reference terms.

* add the privilege "Get Concept Map Types" since it is required as well

see https://issues.openmrs.org/browse/LUI-101