### PR TITLE
LUI-102 Hide concept stats in conceptSidebar if not allowed

### DIFF
--- a/omod/src/main/webapp/admin/dictionary/conceptSidebar.jsp
+++ b/omod/src/main/webapp/admin/dictionary/conceptSidebar.jsp
@@ -16,52 +16,54 @@
 		target="_blank"><openmrs:message code="Concept.wikipedia" /></a>
 </fieldset>
 
-<fieldset>
-	<legend><openmrs:message code="Concept.usage" /></legend>
-	<c:if test="${command.concept.conceptId!=null}">
-	<h4><openmrs:message code="dictionary.numobs" arguments="${command.numberOfObsUsingThisConcept}" /></h4>
+<openmrs:hasPrivilege hasAll="true" privilege="Get Forms,Get Observations,Get Patient Programs" >
+	<fieldset>
+		<legend><openmrs:message code="Concept.usage" /></legend>
+		<c:if test="${command.concept.conceptId!=null}">
+		<h4><openmrs:message code="dictionary.numobs" arguments="${command.numberOfObsUsingThisConcept}" /></h4>
 
-	<c:if test="${fn:length(command.questionsAnswered) > 0}">
-		<h4><openmrs:message code="dictionary.questionsAnswered" /></h4><ul>
-		<c:forEach items="${command.questionsAnswered}" var="question">
-			<li><a href="concept.htm?conceptId=${question.conceptId}"><openmrs:format concept="${question}" /></a></li>
-		</c:forEach></ul>
-	</c:if>
-	
-	<c:if test="${fn:length(command.containedInSets) > 0}">
-		<h4><openmrs:message code="dictionary.containedInSets" /></h4><ul>
-		<c:forEach items="${command.containedInSets}" var="set">
-			<li><a href="concept.htm?conceptId=${set.conceptSet.conceptId}"><openmrs:format concept="${set.conceptSet}" /></a><br/></li>
-		</c:forEach></ul>
-	</c:if>
-
-	<c:forEach items="${command.conceptUsage}" var="conceptUsageExt">
-		<openmrs:hasPrivilege privilege="${conceptUsageExt.requiredPrivilege}">
-		<c:if test="${fn:length(conceptUsageExt.conceptUsage) > 0}">
-			<h4><openmrs:message code="${conceptUsageExt.header}" /></h4>
-			<ul>
-				<c:forEach items="${conceptUsageExt.conceptUsage}" var="usage">
-					<li><a href="${pageContext.request.contextPath}${usage.url}">
-							<c:if test="${usage.strike}"><strike></c:if>
-								${usage.label}
-							<c:if test="${usage.strike}"></strike></c:if>
-						</a>
-					</li>
-				</c:forEach>
-			</ul>
-		</c:if>
-		</openmrs:hasPrivilege>
-	</c:forEach>
-
-	<openmrs:extensionPoint pointId="org.openmrs.concept.usage" type="html" requiredClass="org.openmrs.module.web.extension.ConceptUsageExtension">
-		<openmrs:hasPrivilege privilege="${extension.requiredPrivilege}">
-		<c:if test="${fn:length(extension.conceptUsage) > 0}">
-			<h4>${extension.header}</h4>
-			<ul><c:forEach items="${extension.conceptUsage}" var="usage">
-			<li><a href="<openmrs_tag:url value="${usage.url}"/>">${usage.label}</a></br></li>
+		<c:if test="${fn:length(command.questionsAnswered) > 0}">
+			<h4><openmrs:message code="dictionary.questionsAnswered" /></h4><ul>
+			<c:forEach items="${command.questionsAnswered}" var="question">
+				<li><a href="concept.htm?conceptId=${question.conceptId}"><openmrs:format concept="${question}" /></a></li>
 			</c:forEach></ul>
 		</c:if>
-		</openmrs:hasPrivilege>
-	</openmrs:extensionPoint>
-	</c:if>
-</fieldset>
+
+		<c:if test="${fn:length(command.containedInSets) > 0}">
+			<h4><openmrs:message code="dictionary.containedInSets" /></h4><ul>
+			<c:forEach items="${command.containedInSets}" var="set">
+				<li><a href="concept.htm?conceptId=${set.conceptSet.conceptId}"><openmrs:format concept="${set.conceptSet}" /></a><br/></li>
+			</c:forEach></ul>
+		</c:if>
+
+		<c:forEach items="${command.conceptUsage}" var="conceptUsageExt">
+			<openmrs:hasPrivilege privilege="${conceptUsageExt.requiredPrivilege}">
+			<c:if test="${fn:length(conceptUsageExt.conceptUsage) > 0}">
+				<h4><openmrs:message code="${conceptUsageExt.header}" /></h4>
+				<ul>
+					<c:forEach items="${conceptUsageExt.conceptUsage}" var="usage">
+						<li><a href="${pageContext.request.contextPath}${usage.url}">
+								<c:if test="${usage.strike}"><strike></c:if>
+									${usage.label}
+								<c:if test="${usage.strike}"></strike></c:if>
+							</a>
+						</li>
+					</c:forEach>
+				</ul>
+			</c:if>
+			</openmrs:hasPrivilege>
+		</c:forEach>
+
+		<openmrs:extensionPoint pointId="org.openmrs.concept.usage" type="html" requiredClass="org.openmrs.module.web.extension.ConceptUsageExtension">
+			<openmrs:hasPrivilege privilege="${extension.requiredPrivilege}">
+			<c:if test="${fn:length(extension.conceptUsage) > 0}">
+				<h4>${extension.header}</h4>
+				<ul><c:forEach items="${extension.conceptUsage}" var="usage">
+				<li><a href="<openmrs_tag:url value="${usage.url}"/>">${usage.label}</a></br></li>
+				</c:forEach></ul>
+			</c:if>
+			</openmrs:hasPrivilege>
+		</openmrs:extensionPoint>
+		</c:if>
+	</fieldset>
+</openmrs:hasPrivilege>

--- a/omod/src/main/webapp/dictionary/conceptSidebar.jsp
+++ b/omod/src/main/webapp/dictionary/conceptSidebar.jsp
@@ -16,52 +16,54 @@
 		target="_blank"><openmrs:message code="Concept.wikipedia" /></a>
 </fieldset>
 
-<fieldset>
-	<legend><openmrs:message code="Concept.usage" /></legend>
-	<c:if test="${command.concept.conceptId!=null}">
-	<h4><openmrs:message code="dictionary.numobs" arguments="${command.numberOfObsUsingThisConcept}" /></h4>
+<openmrs:hasPrivilege hasAll="true" privilege="Get Forms,Get Observations,Get Patient Programs" >
+	<fieldset>
+		<legend><openmrs:message code="Concept.usage" /></legend>
+		<c:if test="${command.concept.conceptId!=null}">
+		<h4><openmrs:message code="dictionary.numobs" arguments="${command.numberOfObsUsingThisConcept}" /></h4>
 
-	<c:if test="${fn:length(command.questionsAnswered) > 0}">
-		<h4><openmrs:message code="dictionary.questionsAnswered" /></h4><ul>
-		<c:forEach items="${command.questionsAnswered}" var="question">
-			<li><a href="concept.htm?conceptId=${question.conceptId}"><openmrs:format concept="${question}" /></a></li>
-		</c:forEach></ul>
-	</c:if>
-	
-	<c:if test="${fn:length(command.containedInSets) > 0}">
-		<h4><openmrs:message code="dictionary.containedInSets" /></h4><ul>
-		<c:forEach items="${command.containedInSets}" var="set">
-			<li><a href="concept.htm?conceptId=${set.conceptSet.conceptId}"><openmrs:format concept="${set.conceptSet}" /></a><br/></li>
-		</c:forEach></ul>
-	</c:if>
-
-	<c:forEach items="${command.conceptUsage}" var="conceptUsageExt">
-		<openmrs:hasPrivilege privilege="${conceptUsageExt.requiredPrivilege}">
-		<c:if test="${fn:length(conceptUsageExt.conceptUsage) > 0}">
-			<h4><openmrs:message code="${conceptUsageExt.header}" /></h4>
-			<ul>
-				<c:forEach items="${conceptUsageExt.conceptUsage}" var="usage">
-					<li><a href="${pageContext.request.contextPath}${usage.url}">
-							<c:if test="${usage.strike}"><strike></c:if>
-								${usage.label}
-							<c:if test="${usage.strike}"></strike></c:if>
-						</a>
-					</li>
-				</c:forEach>
-			</ul>
-		</c:if>
-		</openmrs:hasPrivilege>
-	</c:forEach>
-
-	<openmrs:extensionPoint pointId="org.openmrs.concept.usage" type="html" requiredClass="org.openmrs.module.web.extension.ConceptUsageExtension">
-		<openmrs:hasPrivilege privilege="${extension.requiredPrivilege}">
-		<c:if test="${fn:length(extension.conceptUsage) > 0}">
-			<h4>${extension.header}</h4>
-			<ul><c:forEach items="${extension.conceptUsage}" var="usage">
-			<li><a href="<openmrs_tag:url value="${usage.url}"/>">${usage.label}</a></br></li>
+		<c:if test="${fn:length(command.questionsAnswered) > 0}">
+			<h4><openmrs:message code="dictionary.questionsAnswered" /></h4><ul>
+			<c:forEach items="${command.questionsAnswered}" var="question">
+				<li><a href="concept.htm?conceptId=${question.conceptId}"><openmrs:format concept="${question}" /></a></li>
 			</c:forEach></ul>
 		</c:if>
-		</openmrs:hasPrivilege>
-	</openmrs:extensionPoint>
-	</c:if>
-</fieldset>
+
+		<c:if test="${fn:length(command.containedInSets) > 0}">
+			<h4><openmrs:message code="dictionary.containedInSets" /></h4><ul>
+			<c:forEach items="${command.containedInSets}" var="set">
+				<li><a href="concept.htm?conceptId=${set.conceptSet.conceptId}"><openmrs:format concept="${set.conceptSet}" /></a><br/></li>
+			</c:forEach></ul>
+		</c:if>
+
+		<c:forEach items="${command.conceptUsage}" var="conceptUsageExt">
+			<openmrs:hasPrivilege privilege="${conceptUsageExt.requiredPrivilege}">
+			<c:if test="${fn:length(conceptUsageExt.conceptUsage) > 0}">
+				<h4><openmrs:message code="${conceptUsageExt.header}" /></h4>
+				<ul>
+					<c:forEach items="${conceptUsageExt.conceptUsage}" var="usage">
+						<li><a href="${pageContext.request.contextPath}${usage.url}">
+								<c:if test="${usage.strike}"><strike></c:if>
+									${usage.label}
+								<c:if test="${usage.strike}"></strike></c:if>
+							</a>
+						</li>
+					</c:forEach>
+				</ul>
+			</c:if>
+			</openmrs:hasPrivilege>
+		</c:forEach>
+
+		<openmrs:extensionPoint pointId="org.openmrs.concept.usage" type="html" requiredClass="org.openmrs.module.web.extension.ConceptUsageExtension">
+			<openmrs:hasPrivilege privilege="${extension.requiredPrivilege}">
+			<c:if test="${fn:length(extension.conceptUsage) > 0}">
+				<h4>${extension.header}</h4>
+				<ul><c:forEach items="${extension.conceptUsage}" var="usage">
+				<li><a href="<openmrs_tag:url value="${usage.url}"/>">${usage.label}</a></br></li>
+				</c:forEach></ul>
+			</c:if>
+			</openmrs:hasPrivilege>
+		</openmrs:extensionPoint>
+		</c:if>
+	</fieldset>
+</openmrs:hasPrivilege>


### PR DESCRIPTION
conceptForm.jsp includes conceptSidebar.jsp and only requires privilege "Manage
Concepts" altough privileges

"Get Forms"
"Get Observations"
"Get Patient Programs"

are needed to show the concepts stats. Page shows APIAuthorizationException if
one is missing.

* add hasPrivilege tag around code related to concept stats in the
conceptSidebar so it just doesnt show and conceptForm loads fine showing the
concept.

see https://issues.openmrs.org/browse/LUI-102