### PR TITLE
LUI-126: Wildcard selector * is being used in openmrs.css

### DIFF
--- a/omod/src/main/webapp/resources/css/openmrs.css
+++ b/omod/src/main/webapp/resources/css/openmrs.css
@@ -1,4 +1,6 @@
 html {
+	font-family: Verdana, 'Lucida Grande', 'Trebuchet MS', Arial, Sans-Serif;
+    -moz-box-sizing: border-box;  /* Use IE-like Border-Box model */
 	height: 100%;
 	width: 100%;
 }
@@ -78,15 +80,10 @@ img.bar-round-reduced50 {
 		color: #ffffff;
 	}
 
+	
 * html #pageBody {
 	height: 100%;
 }
-
-* {
-	font-family: Verdana, 'Lucida Grande', 'Trebuchet MS', Arial, Sans-Serif;
-    -moz-box-sizing: border-box;  /* Use IE-like Border-Box model */
-}
-
 h1, h2, h3, h4, h5 {
 	margin-top: 5px;
 	margin-bottom: 7px;


### PR DESCRIPTION
Continuation From:
https://github.com/openmrs/openmrs-module-legacyui/pull/84

Why?
Change Of Branch (Master -> LUI-126)

https://issues.openmrs.org/browse/LUI-126

Fixes Use Of CSS Wildcard Selector and Moves It All to the main HTML {} Tag