### PR TITLE
LUI-48: display retired answer concept by (Retired)

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
@@ -1054,7 +1054,7 @@ public class ConceptFormController extends SimpleFormController {
 					name = answer.getAnswerDrug().getFullName(locale);
 				}
 				if (answer.getAnswerConcept().isRetired()) {
-					name = "<span class='retired'>" + name + "</span>";
+					name = name + " (Retired)";
 				}
 				conceptAnswers.put(key, name);
 			}


### PR DESCRIPTION
Please refer to intro tickets: Retired Answer Concepts show HTML code in the list
https://issues.openmrs.org/browse/LUI-48


Before bugfix
![test](https://user-images.githubusercontent.com/34839664/36937015-ecda7eaa-1f47-11e8-9df3-d31f811b32a7.PNG)

After fix
![retired](https://user-images.githubusercontent.com/34839664/36936989-97c85a90-1f47-11e8-9ab8-611b63705fae.PNG)
