### PR TITLE
LUI-80: .../openmrs/options.form should have one field for Old Passwo…

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
@@ -182,13 +182,7 @@ public class OptionsFormController extends SimpleFormController {
 				catch (APIException e) {
 					errors.rejectValue("oldPassword", "error.password.match");
 				}
-			} else {
-				// if they left the old password blank but filled in new
-				// password
-				if (!"".equals(opts.getNewPassword())) {
-					errors.rejectValue("oldPassword", "error.password.incorrect");
-				}
-			}
+			} 
 			
 			if (!"".equals(opts.getSecretQuestionPassword())) {
 				if (!errors.hasErrors()) {
@@ -203,7 +197,7 @@ public class OptionsFormController extends SimpleFormController {
 			} else if (!"".equals(opts.getSecretAnswerNew())) {
 				// if they left the old password blank but filled in new
 				// password
-				errors.rejectValue("secretQuestionPassword", "error.password.incorrect");
+				errors.rejectValue("secretQuestionPassword", "Enter old password");
 			}
 			
 			String notifyType = opts.getNotification();


### PR DESCRIPTION
…rd and dispay right validation message for it when submitted as
Ticket ID: https://issues.openmrs.org/browse/LUI-80
Issue worked on: Removed one old password field, and changed output to enter password rather than password incorrect as explained in the ticket description