### PR TITLE
LUI-153: Footer to show optional extra data from runtime properties

### DIFF
--- a/omod/src/main/java/org/openmrs/template/web/controller/FooterFullController.java
+++ b/omod/src/main/java/org/openmrs/template/web/controller/FooterFullController.java
@@ -1,0 +1,26 @@
+package org.openmrs.template.web.controller;
+
+import org.openmrs.api.context.Context;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+
+public class FooterFullController {
+	
+
+	@RequestMapping("/template/footerFull.htm")
+	public String footerFull(Model model) {
+
+		if ((Context.getMessageSourceService().getMessage("legacyui.footer.extradata")) != null) {
+
+			String footerExtraData = Context.getMessageSourceService().getMessage("legacyui.footer.extradata");
+
+			model.addAttribute("footerExtraData", footerExtraData);
+		}
+
+		return "module/legacyui/template/footerFull";
+	}
+
+}

--- a/omod/src/main/webapp/template/footer.jsp
+++ b/omod/src/main/webapp/template/footer.jsp
@@ -6,6 +6,6 @@
 		<%@ include file="footerMinimal.jsp" %>
 	</c:when>
 	<c:otherwise>
-		<%@ include file="footerFull.jsp" %>
+		<jsp:include page="/template/footerFull.htm" />
 	</c:otherwise>
 </c:choose>

--- a/omod/src/main/webapp/template/footerFull.jsp
+++ b/omod/src/main/webapp/template/footerFull.jsp
@@ -1,3 +1,4 @@
+<%@ include file="/WEB-INF/view/module/legacyui/template/include.jsp" %>
 		<br/>
 		</div>
 	</div>
@@ -44,6 +45,7 @@
 			<span id="buildDate"><openmrs:message code="footer.lastBuild"/>: <%= org.openmrs.web.WebConstants.BUILD_TIMESTAMP %></span>
 			
 			<span id="codeVersion"><openmrs:message code="footer.version"/>: ${openmrsVersion}</span>
+			<c:if test="${not empty footerExtraData}"><span id="extraData">${footerExtraData}</span> </c:if>
 			
 			<span id="poweredBy"><a href="http://openmrs.org"><openmrs:message code="footer.poweredBy"/> <img border="0" align="top" src="<%= request.getContextPath() %>/moduleResources/legacyui/images/openmrs_logo_tiny.png"/></a></span>
 		</div>


### PR DESCRIPTION
Ticket ID:https://issues.openmrs.org/browse/LUI-153


Description

Added a controller that  helps to pick  the extra data from the messages.properties file and the extra data is added to the footerFull.jsp during rendering.
Added screen shorts to the ticket ID plus some comments