### PR TITLE
LUI-173: Encoding of single role link URL on roleList.jsp.

### DIFF
--- a/omod/src/main/webapp/admin/users/roleList.jsp
+++ b/omod/src/main/webapp/admin/users/roleList.jsp
@@ -32,7 +32,10 @@
 				</c:if>
 			</td>
 			<td style="white-space: nowrap">
-				<a href="role.form?roleName=<c:out value="${map.key.role}"/>">
+				<c:url value="role.form" var="url">
+					<c:param name="roleName" value="${map.key.role}" />
+				</c:url>
+				<a href="${url}">
 					<c:out value="${map.key.role}"/>
 				</a>
 			</td>


### PR DESCRIPTION
**Ticket:** [LUI-173](https://issues.openmrs.org/browse/LUI-173)

**Description:** Changed the href link on Role Management section to properly encode the role name that is passed as an URL parameter.