### PR TITLE
EMPT-67: Fixed XSS vulnerability in alert header

### DIFF
--- a/omod/src/main/webapp/template/headerFull.jsp
+++ b/omod/src/main/webapp/template/headerFull.jsp
@@ -166,7 +166,7 @@
 						<a href="#markRead" onClick="return markAlertRead(this, '${alert.alertId}')" HIDEFOCUS class="markAlertRead">
 							<img src="${pageContext.request.contextPath}/images/markRead.gif" alt='<openmrs:message code="Alert.mark"/>' title='<openmrs:message code="Alert.mark"/>'/> <span class="markAlertText"><openmrs:message code="Alert.markAsRead"/></span>
 						</a>
-						${alert.text} ${alert.dateToExpire} 
+						<c:out value='${alert.text}'/> ${alert.dateToExpire}
 					</div>
 				<c:if test="${varStatus.last}">
 					</div>


### PR DESCRIPTION
### Description of what I changed

@isears 
Fixed the display format of alerts in `headerFull.jsp` to display the alert titles as text rather than as HTML. 

### Link to Ticket

https://issues.openmrs.org/browse/RA-1865  

### Issue I worked on

This fix protects against reflected XSS that is inputted to an alert title. When a script or other malicious input is inserted, it will be executed as HTML each time a page with the header is loaded for the user to which the alert was assigned. The page is loaded on nearly every legacy UI page. The fix is locaed in the `headerFull.jsp` file, as this file is the one that displays the alert title and is vulnerable to the XSS attack.

### Before Fix
Pop-ups with the message from the injected script tag:  
![image](https://user-images.githubusercontent.com/35906111/110372871-d0799280-801c-11eb-9381-61b21f747632.png)  
  
Alert text is not shown as it is part of the HTML now:  
![image](https://user-images.githubusercontent.com/35906111/110373117-22221d00-801d-11eb-928d-54e463a6fb6b.png)
  

### After Fix
Alert title is now shown as text rather than interpreted as HTML
![image](https://user-images.githubusercontent.com/35906111/110371563-251c0e00-801b-11eb-8eb5-3c2d35076059.png)


#### Steps to reproduce

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Select “System Administration”
4. Select “Advanced Administration”
5. Select “Manage Alerts” 
6. Select “Add Alert”
7. In the “Alert Text” input field, enter `<script>alert(1)</script>`
8. Next to the "Recipients" input field, click "Add", then select user "Super User" (_Note:_ it is important that you choose this user so that the alert appears for the currently logged in user, which is Super User since we logged in as Admin)
9. Click "Save Alert"
  
_An alert with the text "1" will appear on the screen each time a page with the alert header is loaded._
