### PR TITLE
RA-1875: EMPT59  Fixed XSS vulnerability in editPersonInfo and personForm

### DIFF
--- a/omod/src/main/webapp/admin/person/include/editPersonInfo.jsp
+++ b/omod/src/main/webapp/admin/person/include/editPersonInfo.jsp
@@ -210,11 +210,11 @@
 <c:choose>
     <c:when test="${not empty patient}">
         <c:set var="voided" value="${patient.voided}" />
-        <c:set var="voidReason" value="${patient.voidReason}" />
+        <c:set var="voidReason" value="<c:out value='${patient.voidReason}'/>" />
     </c:when>
     <c:otherwise>
         <c:set var="voided" value="${person.voided}" />
-        <c:set var="voidReason" value="${person.voidReason}" />
+        <c:set var="voidReason" value="<c:out value='${person.voidReason}'/>" />
     </c:otherwise>
 </c:choose>
 

--- a/omod/src/main/webapp/admin/person/personForm.jsp
+++ b/omod/src/main/webapp/admin/person/personForm.jsp
@@ -249,7 +249,7 @@
     <div>
     	<c:if test="${person.personVoidedBy.personName != null}"><openmrs:message code="general.byPerson"/> <c:out value="${person.personVoidedBy.personName}" /></c:if>
     	<c:if test="${person.personDateVoided != null}"> <openmrs:message code="general.onDate"/> <openmrs:formatDate date="${person.personDateVoided}" type="long" /> </c:if> 
-   		<c:if test="${person.personVoidReason != ''}"> - ${person.personVoidReason} </c:if>
+   		<c:if test="${person.personVoidReason != ''}"> - <c:out value='${person.personVoidReason}'/> </c:if>
     </div>
 	<div>
 		<form action="" method="post" ><input type="submit" name="action" value="<openmrs:message code="Person.unvoid"/>" /></form></div> 


### PR DESCRIPTION
### Description of what I changed
Added c:out for the person and patient voidReason in editPersonInfo and personVoidReason in personForm


### Issue I worked on
Sanitized input for the reason you delete a person in the legacyui. The script would be executed twice because it gets reference twice when you delete but now will not be executed with this patch.

It can be reproduced following 
1. Launch OpenMRS application using the URL: http://localhost:8800/openmrs
2. Provide the following info and click login​Username​ as ​admin​ Password​ ​ as ​admin123 Location as ​Inpatient
3. Click on the tiles in this order: System Administration ‹ Advanced Administration.
4. Under the Person category, click on Manage Persons, and on the page that appears, click on Create Person.
5. Enter the details as prompted and click on the Create Person button.
6. In the form that appears, provide input for the mandatory field ie, Family name.
7. Click on the Save Person button.
8. Now go to delete the user and under reason to delete, paste the following script: “<script>alert("Error!")</script>”.
- The script gets executed.


### Link to ticket
https://issues.openmrs.org/browse/RA-1875

