### PR TITLE
RA-1865: Fix vulnerable question concept in Manage Observations

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
@@ -46,6 +46,7 @@ import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.validator.ConceptReferenceTermValidator;
+import org.owasp.encoder.Encode;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ObjectError;
@@ -220,8 +221,11 @@ public class DWRConceptService {
 			}
 			
 			if (searchResults.size() < 1) {
-				objectList.add(Context.getMessageSourceService().getMessage("general.noMatchesFoundInLocale",
-				    new Object[] { "<b>" + phrase + "</b>", OpenmrsUtil.join(searchLocales, ", ") }, Context.getLocale()));
+				String htmlSafePhrase = "<b>" + Encode.forHtml(phrase) + "</b>";
+				objectList.add(Context.getMessageSourceService()
+				        .getMessage("general.noMatchesFoundInLocale",
+				            new Object[] { htmlSafePhrase, OpenmrsUtil.join(searchLocales, ", ") },
+				            Context.getLocale()));
 			} else {
 				// turn searchResults into concept list items
 				// if user wants drug concepts included, append those
@@ -236,8 +240,9 @@ public class DWRConceptService {
 		}
 		
 		if (objectList.size() == 0) {
+			String htmlSafePhrase = "<b>" + Encode.forHtml(phrase) + "</b>";
 			objectList.add(Context.getMessageSourceService().getMessage("general.noMatchesFoundInLocale",
-			    new Object[] { "<b>" + phrase + "</b>", defaultLocale }, Context.getLocale()));
+			    new Object[] { htmlSafePhrase, defaultLocale }, Context.getLocale()));
 		}
 		
 		return objectList;


### PR DESCRIPTION
### Description of what I changed

@isears 
Fixed `DWRConceptService.java` to encode the search result phrase that appears when users search for a Question Concept in the `Manage Observations` page.

_Note_: Since `ui` was not defined in this file, I modeled this fix after [this PR](https://github.com/openmrs/openmrs-module-uiframework/pull/52/files) Please let me know if a different technique to fix the vulnerability is preferred!

### Link to Ticket

https://issues.openmrs.org/browse/RA-1865  

### Issue I worked on

This fix protects against stored XSS that is inputted into the `Question Concept` search field when creating a Observation. The search widget that appears presents a message which reads "No matches found for {search phrase}", which would reflect XSS in the search phrase when it was submitted as the search phrase. 

### Before Fix
Injected iframe appears in search message:
<img width="792" alt="VulnerableEMPT56" src="https://user-images.githubusercontent.com/35906111/112498221-b352fc80-8d5c-11eb-9fdb-d7c5ca8ca878.PNG">

### After Fix
Search message is now shown as text rather than interpreted as HTML:   
<img width="819" alt="FixedEMPT56" src="https://user-images.githubusercontent.com/35906111/112498241-b6e68380-8d5c-11eb-9d80-1b52e48226eb.PNG">

#### Steps to reproduce

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Select “System Administration”
4. Select “Advanced Administration”
5. Select “Manage Observations” 
6. Select “Add Observation”
7. In the “Question Concept” input field, enter `<iframe src=https://www.csc.ncsu.edu/>`
  
_An iframe will appear in the search result._