### PR TITLE
RA-1865 Added HTML escape for search results

### DIFF
--- a/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
+++ b/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
@@ -841,8 +841,7 @@ function OpenmrsSearch(div, showIncludeVoided, searchHandler, selectionHandler, 
                 var data = rowData[c.fieldName];
                 if(data == null)
                     data = " ";
-
-                return data;
+                return $j('<div/>').text(data).html();
             });
 
             //include the attributes

--- a/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
+++ b/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
@@ -823,7 +823,7 @@ function OpenmrsSearch(div, showIncludeVoided, searchHandler, selectionHandler, 
                 $j('#openmrsSearchTable_paginate').show();
             }
 
-            this._updatePageInfo(searchText);
+            this._updatePageInfo($j('<div/>').text(searchText).html());
             if(matchCount == 0){
                 if($j('#openmrsSearchTable_info').is(":visible"))
                     $j('#openmrsSearchTable_info').hide();


### PR DESCRIPTION
### Description of what I changed
When building the search results table, I changed `return data` to ` return $j('<div/>').text(data).html()` in order to prevent Iframes from being shown in the person search results.

This is a very similar issue to the one fixed by Anna [here](https://github.com/openmrs/openmrs-module-legacyui/pull/137).

### Link to ticket
https://issues.openmrs.org/browse/RA-1865

### Issue I worked on
One could create a new person with given name `<iframe src="http://www.ncsu.edu">`. When searching for this person by typing `<iframe`, the results list would display that iframe. In addition, where it says "viewing results for __" would also display a blank iframe.

### Before fix
Searching for `<iframe` when a person with given name `<iframe src="http://www.ncsu.edu">` exists.
![image](https://user-images.githubusercontent.com/29798975/112913832-8e49eb00-90c8-11eb-82e6-db9c954dd296.png)

### After fix
Searching for `<iframe` when a person with given name `<iframe src="http://www.ncsu.edu">` exists.
![image](https://user-images.githubusercontent.com/29798975/112913878-ade11380-90c8-11eb-9ba5-6d900e848a02.png)


### Steps to reproduce
1. Login to OpenMRS as admin.
2. Go to System Admininstration > Advanced Administration > Manage Persons > Create Person
3. Create a person with name `<iframe src="http://www.ncsu.edu">`
4. On the page with advanced details make sure that the given name is `<iframe src="http://www.ncsu.edu">`, as it will automatically split into given name and last name otherwise.
5. Save this person.
6. Go back to Manage Persons.
7. Search for `<iframe`
8. The iframe of the site will be displayed in the results, and a blank iframe will be shown after the "viewing results for.." text.

