### PR TITLE
RA-1865: Fix XSS Vulnerability in Manage Fields List

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
@@ -32,6 +32,7 @@ import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.FormUtil;
 import org.openmrs.web.WebUtil;
+import org.owasp.encoder.Encode;
 
 /**
  * A collection of methods used by DWR for access forms, fields, and FormFields. These methods are
@@ -106,7 +107,9 @@ public class DWRFormService {
 		List<FieldListItem> fields = new Vector<FieldListItem>();
 		
 		for (Field field : Context.getFormService().getFields(txt)) {
-			fields.add(new FieldListItem(field, Context.getLocale()));
+			FieldListItem htmlSafeField = new FieldListItem(field, Context.getLocale());
+			htmlSafeField.setName(Encode.forHtml(htmlSafeField.getName()));
+			fields.add(htmlSafeField);
 		}
 		
 		return fields;


### PR DESCRIPTION
### Description of what I changed

@isears 
Fixed `DWRFormService.java` to encode elements of the `FieldListItem` object before passing it to the UI to display in the search results on the `Manage Fields` page.

_Note_: Since `ui` was not defined in this file, I modeled this fix after [this PR](https://github.com/openmrs/openmrs-module-uiframework/pull/52/files).

### Link to Ticket

https://issues.openmrs.org/browse/RA-1865  

### Issue I worked on

This fix protects against stored XSS that is inputted into the `Name` when creating a new Field. After creating the field, when you search that field in the Manage Fields page, the search result table will execute the XSS vulnerability in the results.

### Before Fix
Injected iframe appears in search results:
<img width="740" alt="VulnerableEMPT49" src="https://user-images.githubusercontent.com/35906111/113016889-e7f3f900-914c-11eb-90f7-786ebf5451ee.PNG">


### After Fix
Field name is now shown as text rather than interpreted as HTML:   
<img width="418" alt="FixedEMPT49" src="https://user-images.githubusercontent.com/35906111/113016927-f3472480-914c-11eb-98fc-48294989138b.PNG">

#### Steps to reproduce

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Select “System Administration”
4. Select “Advanced Administration”
5. Select “Manage Fields” 
6. Select “Add New Field”
7. In the “Field Name” input field, enter `<iframe src=https://www.csc.ncsu.edu/>`
8. Click "Save"
9. Navigate to the "Manage Fields" tab
10. In the search bar, type "iframe". Do not click enter, the search results will populate.

_An iframe will appear in the search result row of the encounter you created under the "Name" column._