### PR TITLE
RA-1865: Fix XSS in Add Encounter to Visit

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
@@ -112,7 +112,9 @@ public class DWREncounterService {
 			}
 			
 			if (encs.size() == 0) {
-				objectList.add(mss.getMessage("Encounter.noMatchesFound", new Object[] { phrase }, Context.getLocale()));
+				String htmlSafePhrase = "<b>" + Encode.forHtml(phrase) + "</b>";
+				objectList.add(mss.getMessage("Encounter.noMatchesFound", new Object[] { htmlSafePhrase },
+				    Context.getLocale()));
 			} else {
 				objectList = new Vector<Object>(encs.size());
 				for (Encounter e : encs) {


### PR DESCRIPTION
### Description of what I changed

@isears 
Fixed `DWREncounterService.java` to encode the search result phrase that appears when users search for an encounter to add in the `Edit Visit` page.

_Note_: Since `ui` was not defined in this file, I modeled this fix after [this PR](https://github.com/openmrs/openmrs-module-uiframework/pull/52/files).

### Link to Ticket

https://issues.openmrs.org/browse/RA-1865  

### Issue I worked on

This fix protects against reflected XSS that is executed when a user searches for an encounter to add on the Edit Visit page. Specifically, this vulnerability fixes the vulnerability that occurs when no search results match the search phrase. The search widget that appears presents a message which reads "No matches found for {search phrase}", which reflects XSS in the search phrase. 

### Before Fix
Injected iframe appears in search message:
<img width="462" alt="VulnerableEmpt71" src="https://user-images.githubusercontent.com/35906111/113024409-b5e69500-9154-11eb-835d-7bf0cf54f8b0.PNG">

### After Fix
Search message is now shown as text rather than interpreted as HTML:   
<img width="543" alt="FixedEmpt71" src="https://user-images.githubusercontent.com/35906111/113024473-c7c83800-9154-11eb-972b-215e97db699d.PNG">


#### Steps to reproduce

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Select “System Administration”
4. Select “Advanced Administration”
5. Select “Manage Patients” 
1. Type in “John” in the search box.
2. Select the “John D Patient” record.
3. Click on “View Patient Dashboard”.
4. Click on the “Start Visit” button.
5. Click on the “Add Encounter” button.
6. Enter <iframe src=https://www.ncsu.edu/> in the text box that appears
  
_An iframe will appear in the search result._