### PR TITLE
RA-1865: Fix XSS vulnerability in Field Type and Description of Manage Fields

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
@@ -109,6 +109,14 @@ public class DWRFormService {
 		for (Field field : Context.getFormService().getFields(txt)) {
 			FieldListItem htmlSafeField = new FieldListItem(field, Context.getLocale());
 			htmlSafeField.setName(Encode.forHtml(htmlSafeField.getName()));
+			htmlSafeField.setFieldTypeName(Encode.forHtml(htmlSafeField.getFieldTypeName()));
+			
+			// Add the description only if it was given
+			String description = htmlSafeField.getDescription();
+			if (description != null) {
+				htmlSafeField.setDescription(Encode.forHtml(description));
+			}
+			
 			fields.add(htmlSafeField);
 		}
 		


### PR DESCRIPTION
### Description of what I changed

@isears 
Fixed `DWRFormService.java` to encode the `fieldType` and `description` attributes of the `FieldListItem` object before passing it to the UI to display in the search results on the `Manage Fields` page. 

**This change is very similar to [this PR](https://github.com/openmrs/openmrs-module-legacyui/pull/153) and probably should have been fixed there had I realized this were a vulnerability. I went ahead and tested the Description column for a vulnerability as well, and it had one that I fixed (again, should have been fixed in the first PR).

_Note_: Since `ui` was not defined in this file, I modeled this fix after [this PR](https://github.com/openmrs/openmrs-module-uiframework/pull/52/files).

### Link to Ticket

https://issues.openmrs.org/browse/RA-1865  

### Issue I worked on

This fix protects against stored XSS that is inputted into the name of a new `Field Type` object that is later assigned to a new Field and the `Description` attribute of a new Field. After creating the field, when you search that field in the Manage Fields page, the search result table will execute the XSS vulnerability in the results under the `Field Type` and `Description` columns.

### Before Fix
Injected iframe appears in search results:

Field Type:   
<img width="358" alt="VulnerableEMPT50" src="https://user-images.githubusercontent.com/35906111/113916901-8c5de700-97ae-11eb-8c4b-54a7852f81cd.PNG">  

Description:  
<img width="347" alt="VulnerableEMPT50-Part2" src="https://user-images.githubusercontent.com/35906111/113916848-7bad7100-97ae-11eb-9588-c283e0eaefe8.PNG">

### After Fix
Field type is now shown as text rather than interpreted as HTML:   
<img width="361" alt="FixedEMPT50" src="https://user-images.githubusercontent.com/35906111/113916954-9a136c80-97ae-11eb-9c7f-171eec8989f3.PNG">

Description is now shown as text rather than interpreted as HTML:   
<img width="350" alt="FixedEMPT50-Part2" src="https://user-images.githubusercontent.com/35906111/113916962-9bdd3000-97ae-11eb-90ef-977ce9c2d702.PNG">  

#### Steps to reproduce

1. Launch the OpenMRS application.
2. Login with username "Admin" and password "Admin123" with location as Inpatient Ward.
3. Select “System Administration”
4. Select “Advanced Administration”
1. Click on “Manage Field Types” and then “Add Field Type”.
1. Enter `<iframe src=’http://ncsu.edu’>` as Name.
1. Hit Save Field Type.
1. Click on “Manage Fields” and then “Add New Field”.
1. Enter “test” in the Field Name text box and select <iframe src=’http://ncsu.edu’> for Field Type.
1. Enter `<iframe src=’http://ncsu.edu’>` as Description.
1. Hit Save.
1. In the Find Fields By Name text box, enter “test”. Do not click enter, the results will populate automatically.

_An iframe will appear in the search result row of the field you created under the "Field Type" and "Description" columns._