### PR TITLE
Changed DWRPersonService for EMPT60

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
@@ -32,6 +32,7 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.openmrs.web.WebUtil;
 
 /**
  * DWR methods for ajaxy effects on {@link Person} objects.
@@ -271,14 +272,22 @@ public class DWRPersonService {
 				// if no roles were given, search for normal people
 				PersonService ps = Context.getPersonService();
 				for (Person p : ps.getPeople(searchPhrase, null, includeVoided)) {
-					personList.add(PersonListItem.createBestMatch(p));
+					PersonListItem personListItem = PersonListItem.createBestMatch(p);
+					personListItem.setGivenName(WebUtil.escapeHTML(personListItem.getGivenName()));
+					personListItem.setMiddleName(WebUtil.escapeHTML(personListItem.getMiddleName()));
+					personListItem.setFamilyName(WebUtil.escapeHTML(personListItem.getFamilyName()));
+					personList.add(personListItem);
 				}
 				
 				// also search on patient identifier if the query contains a number
 				if (searchPhrase.matches(".*\\d+.*")) {
 					PatientService patientService = Context.getPatientService();
 					for (Patient p : patientService.getPatients(searchPhrase, null, null, false)) {
-						personList.add(PersonListItem.createBestMatch(p));
+						PersonListItem personListItem = PersonListItem.createBestMatch(p);
+						personListItem.setGivenName(WebUtil.escapeHTML(personListItem.getGivenName()));
+						personListItem.setMiddleName(WebUtil.escapeHTML(personListItem.getMiddleName()));
+						personListItem.setFamilyName(WebUtil.escapeHTML(personListItem.getFamilyName()));
+						personList.add(personListItem);
 					}
 				}
 				

--- a/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
+++ b/omod/src/main/webapp/resources/scripts/jquery-ui/js/openmrsSearch.js
@@ -823,7 +823,7 @@ function OpenmrsSearch(div, showIncludeVoided, searchHandler, selectionHandler, 
                 $j('#openmrsSearchTable_paginate').show();
             }
 
-            this._updatePageInfo($j('<div/>').text(searchText).html());
+            this._updatePageInfo(searchText);
             if(matchCount == 0){
                 if($j('#openmrsSearchTable_info').is(":visible"))
                     $j('#openmrsSearchTable_info').hide();
@@ -841,7 +841,7 @@ function OpenmrsSearch(div, showIncludeVoided, searchHandler, selectionHandler, 
                 var data = rowData[c.fieldName];
                 if(data == null)
                     data = " ";
-                return $j('<div/>').text(data).html();
+                return data;
             });
 
             //include the attributes


### PR DESCRIPTION
Link to ticket
https://issues.openmrs.org/browse/RA-1865

Reverted the changes for https://github.com/openmrs/openmrs-module-legacyui/pull/152 and add a serverside fix.


The issue I worked on
One could create a new person with given name <iframe src="http://www.ncsu.edu">. When searching for this person by typing <iframe, the results list would display that iframe. In addition, where it says "viewing results for __" would also display a blank iframe.

Before fix
Searching for <iframe when a person with given name <iframe src="http://www.ncsu.edu"> exists.
image

After fix
Searching for <iframe when a person with given name <iframe src="http://www.ncsu.edu"> does not exists.
image

Steps to reproduce
Login to OpenMRS as admin.
Go to System Admininstration > Advanced Administration > Manage Persons > Create Person
Create a person with name <iframe src="http://www.ncsu.edu">
On the page with advanced details make sure that the given name is <iframe src="http://www.ncsu.edu">, as it will automatically split into given name and last name otherwise.
Save this person.
Go back to Manage Persons.
Search for <iframe
The iframe of the site will be displayed in the results, and a blank iframe will be shown after the "viewing results for.." text.
