### PR TITLE
RA-1875: EMPT173 Fixed XSS Vulnerability in Find Patient

### DIFF
--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
@@ -44,6 +44,7 @@ import org.openmrs.module.legacyui.api.LegacyUIService;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.UnallowedIdentifierException;
 import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.web.WebUtil;
 
 /**
  * DWR patient methods. The methods in here are used in the webapp to get data from the database via
@@ -117,7 +118,10 @@ public class DWRPatientService implements GlobalPropertyListener {
 		
 		patientList = new Vector<Object>(patients.size());
 		for (Patient p : patients) {
-			patientList.add(new PatientListItem(p, searchValue));
+			PatientListItem htmlSafePatient = new PatientListItem(p, searchValue);
+			htmlSafePatient.setGivenName(WebUtil.escapeHTML(htmlSafePatient.getGivenName()));
+			htmlSafePatient.setFamilyName(WebUtil.escapeHTML(htmlSafePatient.getFamilyName()));
+			patientList.add(htmlSafePatient);
 		}
 		//no results found and a number was in the search --
 		//should check whether the check digit is correct.


### PR DESCRIPTION
### Description of What I Changed

Encoded name of each patient in DWRPatientService.java to prevent XSS when searching for patients.

### Issue I Worked On

Whenever a patient is created with an iframe or a script as name, the iframe/script will be executed whenever that patient's name would be searched on 'Find/Create Patient' page.

Steps to replicate the vulnerability:

1. Launch OpenMRS application using the URL: http://localhost:8080/openmrs
2. Login with username "Admin" and password "Admin123" with location as "Inpatient Ward".
3. Navigate to 'Register a Patient'.
4. Enter dummy details in required fields as `Given Name: <iframe src=”https://ncsu.edu”/>, Family Name: Family, Gender: Male, Birthdate: 1 January 2000, Address: 123 road` and click 'Confirm' at the end.
5. After getting redirected to the new patient’s dashboard, go to homepage.
6. Navigate to System Administration > Advanced Administration > Manage Patient.
7. In the search box, start typing `<iframe`.

Output: An iframe is displayed in the search results table in the 'Given' column.

### Link to ticket

[RA-1875](https://issues.openmrs.org/browse/RA-1875)

@isears