### PR TITLE
[LUI-48]: Retired Answer Concepts show HTML code in the list

### DIFF
--- a/omod/src/main/webapp/dictionary/concept.jsp
+++ b/omod/src/main/webapp/dictionary/concept.jsp
@@ -224,13 +224,16 @@
 		<c:if test="${command.concept.datatype != null && command.concept.datatype.name == 'Coded'}">
 			<tr class="localeSpecific">
 				<th valign="top"><openmrs:message code="Concept.answers"/></th>
-                <c:forEach items="${command.locales}" var="loc">
-                    <td class="${loc}">
-                        <c:forEach items="${command.conceptAnswersByLocale[loc]}" var="answer">
-                            <a href="concept.htm?conceptId=${fn:substring(answer.key, 0, fn:indexOf(answer.key, '^'))}"><c:out value="${answer.value}" /> (${fn:substring(answer.key, 0, fn:indexOf(answer.key, '^'))})</a><br/>
-                        </c:forEach>
-                    </td>
-                </c:forEach>
+				<c:forEach items="${command.locales}" var="locale">
+					<td class="${locale}">
+						<c:forEach items="${command.conceptAnswersByLocale[locale]}" var="conceptAnswer">
+							<c:set var="conceptId" value="${fn:substring(conceptAnswer.key, 0, fn:indexOf(conceptAnswer.key, '^'))}" />
+							<a href="concept.htm?conceptId=${conceptId}">
+								<c:out value="${conceptAnswer.value}" escapeXml="true"/> (${conceptId})
+							</a><br/>
+						</c:forEach>
+					</td>
+				</c:forEach>
 			</tr>
 		</c:if>
 		<c:if test="${command.concept.numeric}">


### PR DESCRIPTION
## Summary ((https://openmrs.atlassian.net/browse/LUI-48))

- Retired Answer Concepts show HTML code in the list 

screenshots
<img width="1013" alt="Screenshot 2024-04-01 at 13 13 51" src="https://github.com/openmrs/openmrs-module-legacyui/assets/14895251/63d62679-ddbe-4513-bef3-8776ba34aba1">
<img width="1018" alt="Screenshot 2024-04-01 at 13 06 40" src="https://github.com/openmrs/openmrs-module-legacyui/assets/14895251/ea105d4a-fd71-479e-b25c-d705f7a61148">

@dkayiwa , @ibacher  