### PR TITLE
TRUNK-6203: Global properties access should be privileged

### DIFF
--- a/omod/src/main/java/org/openmrs/web/servlet/LoginServlet.java
+++ b/omod/src/main/java/org/openmrs/web/servlet/LoginServlet.java
@@ -33,6 +33,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.context.ContextAuthenticationException;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.OpenmrsCookieLocaleResolver;
 import org.openmrs.web.WebConstants;
 import org.openmrs.web.WebUtil;
@@ -81,8 +82,16 @@ public class LoginServlet extends HttpServlet {
 		// look up the allowed # of attempts per IP
 		Integer allowedLockoutAttempts = 100;
 		
-		String allowedLockoutAttemptsGP = Context.getAdministrationService().getGlobalProperty(
-		    GP_ALLOWED_LOGIN_ATTEMPTS_PER_IP, "100");
+		String allowedLockoutAttemptsGP = "100";
+		try {
+			Context.addProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+			allowedLockoutAttemptsGP = Context.getAdministrationService().getGlobalProperty(
+			    GP_ALLOWED_LOGIN_ATTEMPTS_PER_IP, "100");
+		}
+		finally {
+			Context.removeProxyPrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES);
+		}
+		
 		try {
 			allowedLockoutAttempts = Integer.valueOf(allowedLockoutAttemptsGP.trim());
 		}


### PR DESCRIPTION
After TRUNK-6203, users must possess the 'Get Global Properties' privilege to access global properties. This addition and removal of the global property are necessary for accessing global properties before a user logs in.

Ticket: https://openmrs.atlassian.net/browse/TRUNK-6203