### PR TITLE
LUI-208: Fix Node.appendChild error in search results with newer DWR util.js

### DIFF
--- a/omod/src/main/webapp/resources/scripts/dojo/src/widget/openmrs/OpenmrsSearch.js
+++ b/omod/src/main/webapp/resources/scripts/dojo/src/widget/openmrs/OpenmrsSearch.js
@@ -573,8 +573,33 @@ dojo.widget.defineWidget(
 	},
 	
 	cellCreator: function(options) {
-		if (dwr.util._isHTMLElement(options.data, "td") == true)
-			return options.data;
+		if (dwr.util._isHTMLElement(options.data, "td") == true) {
+			// LUI-208: Create a new td and transfer content from the original.
+			// The newer DWR util.js (from org.openmrs.contrib) always tries to
+			// appendChild(data) on the cell returned by cellCreator. When the
+			// cell IS the data (same object), this causes "Node.appendChild:
+			// The new child is an ancestor of the parent". By returning a
+			// different td object with the same content, we avoid this error.
+			var original = options.data;
+			var td = document.createElement("td");
+			td.className = original.className;
+			td.id = original.id;
+			if (original.colSpan > 1) td.colSpan = original.colSpan;
+			td.onclick = original.onclick;
+			td.onmouseover = original.onmouseover;
+			td.onmouseout = original.onmouseout;
+			while (original.firstChild) {
+				td.appendChild(original.firstChild);
+			}
+			// Clear the original to avoid duplicate ids and stale state
+			// in case DWR appends it as a nested element
+			original.className = '';
+			original.id = '';
+			original.onclick = null;
+			original.onmouseover = null;
+			original.onmouseout = null;
+			return td;
+		}
 		
 		return document.createElement("td");
 	},


### PR DESCRIPTION
## Summary

Fixes [LUI-208](https://openmrs.atlassian.net/browse/LUI-208): On legacyUI >=2.x, pages like **Find Duplicate Patients** and **concept search popups** (e.g., in Manage Programs) throw:

> *"A javascript error has occurred: Node.appendChild: The new child is an ancestor of the parent"*

## Root Cause

The `cellCreator` function in `OpenmrsSearch.js` returned `options.data` directly when it was already a `<td>` element. The newer DWR `util.js` (from `org.openmrs.contrib`) then calls `cell.appendChild(data)` on the returned cell. Since `cell === data` (same object), this is effectively `node.appendChild(node)`, which throws the DOM hierarchy error.

The older DWR `util.js` (from `org.openmrs.directwebremoting`) had a guard (`if (td != reply)`) that skipped content-setting when the cell was the same object as the data. The newer version does not have this guard.

## Fix

Modified `cellCreator` in `OpenmrsSearch.js` to create a **new** `<td>` element and transfer all attributes (`className`, `id`, `colSpan`, event handlers) and child nodes from the original. The original is then cleared to prevent duplicate IDs. Since the returned cell is now a different object from the data, DWR's `appendChild` call operates on two distinct elements and succeeds.

## Changes

| File | Description |
|------|-------------|
| `OpenmrsSearch.js` | Fix `cellCreator` to create new TD instead of returning data directly |
| `DWRPatientServiceTest.java` | 4 new tests for `findDuplicatePatients` and `findPatientsByIdentifier` |
| `DWRConceptServiceTest.java` | 3 new tests for concept search paths |
| `DWRPatientService-duplicatePatients.xml` | Test data for duplicate patient scenario |

## Steps to Verify

1. Run legacyUI with a recent OpenMRS core version
2. Navigate to **Administration > Patients > Find Patients to Merge**
3. Select two attributes (e.g., givenName + gender) and click Search
4. Verify search results appear without JavaScript errors
5. Navigate to **Administration > Programs > Manage Programs > Add new program**
6. Click to select a concept — verify the concept search popup works without errors

[LUI-208]: https://openmrs.atlassian.net/browse/LUI-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ