### PR TITLE
Upgrade commons-fileupload2-jakarta to jakarta-servlet6 2.0.0-M5

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -134,9 +134,9 @@
 
 		<dependency>
 			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-fileupload2-jakarta</artifactId>
-			<version>2.0.0-M1</version>
-            <scope>provided</scope>
+			<artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+			<version>2.0.0-M5</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/omod/src/main/java/org/openmrs/web/xss/XSSFilter.java
+++ b/omod/src/main/java/org/openmrs/web/xss/XSSFilter.java
@@ -21,7 +21,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.web.multipart.support.DefaultMultipartHttpServletRequest;
 
-import static org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload.isMultipartContent;
+import static org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload.isMultipartContent;
 
 public class XSSFilter implements Filter {
 	


### PR DESCRIPTION
Replace obsolete commons-fileupload2-jakarta:2.0.0-M1 with commons-fileupload2-jakarta-servlet6:2.0.0-M5 and update the import in XSSFilter to use the new package. This aligns with the Servlet 6.1 API and commons-fileupload2 version already provided by openmrs-core.