### PR TITLE
Migrate tests from JUnit 4 to JUnit 5

### DIFF
--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -113,6 +113,20 @@
 		</dependency>
 		
 		<!-- End OpenMRS core -->
+
+		<!-- Force aligned JUnit Platform versions to match JUnit Jupiter 6.0.3 -->
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-suite-engine</artifactId>
+			<version>6.0.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<version>6.0.3</version>
+			<scope>test</scope>
+		</dependency>
 		
 		<dependency>
 			<groupId>org.openmrs.contrib</groupId>

--- a/omod/src/test/java/org/openmrs/layout/AddressSupportTest.java
+++ b/omod/src/test/java/org/openmrs/layout/AddressSupportTest.java
@@ -12,14 +12,14 @@ package org.openmrs.layout;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.layout.address.AddressSupport;
 import org.openmrs.layout.address.AddressTemplate;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class AddressSupportTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -41,12 +41,12 @@ public class AddressSupportTest extends BaseModuleWebContextSensitiveTest {
 		//(in the 'web' package differs from the updated classname in the DB
 		String newAddressTemplateClass = "org.openmrs.layout.address.AddressTemplate";
 		String xml = Context.getAdministrationService().getGlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_ADDRESS_TEMPLATE);
-		Assert.assertTrue(StringUtils.contains(xml, newAddressTemplateClass));
-		Assert.assertEquals(newAddressTemplateClass, AddressTemplate.class.getName());
+		Assertions.assertTrue(StringUtils.contains(xml, newAddressTemplateClass));
+		Assertions.assertEquals(newAddressTemplateClass, AddressTemplate.class.getName());
 		
 		AddressSupport addressSupport = AddressSupport.getInstance();
 		List<AddressTemplate> addressTemplates = addressSupport.getAddressTemplate();
-		Assert.assertNotNull(addressTemplates.get(0));
+		Assertions.assertNotNull(addressTemplates.get(0));
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/layout/NameSupportTest.java
+++ b/omod/src/test/java/org/openmrs/layout/NameSupportTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.layout;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.layout.name.NameSupport;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class NameSupportTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -28,10 +28,10 @@ public class NameSupportTest extends BaseModuleWebContextSensitiveTest {
 	@Verifies(value = "getInstance() should return a layout.web.name.NameSupport instance", method = "getInstance()")
 	public void getInstance_shouldFindNameSupportBean() throws Exception {
 		NameSupport nameSupport = NameSupport.getInstance();
-		Assert.assertNotNull(nameSupport);
-		Assert.assertNotNull(nameSupport.getDefaultLayoutFormat());
+		Assertions.assertNotNull(nameSupport);
+		Assertions.assertNotNull(nameSupport.getDefaultLayoutFormat());
 		//make sure that all 5 layout templates defined at the time of the package change continue to work
-		Assert.assertTrue(nameSupport.getLayoutTemplates().size() >= 5);
+		Assertions.assertTrue(nameSupport.getLayoutTemplates().size() >= 5);
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/module/web/controller/ModuleListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/web/controller/ModuleListControllerTest.java
@@ -12,9 +12,9 @@ package org.openmrs.module.web.controller;
 import java.util.Arrays;
 import java.util.List;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.module.Module;
 
 public class ModuleListControllerTest {
@@ -34,10 +34,10 @@ public class ModuleListControllerTest {
 		
 		List<Module> list = new ModuleListController().sortStartupOrder(Arrays.asList(appframework, kenyaemr, kenyaemr,
 		    uilibrary));
-		Assert.assertSame(uilibrary, list.get(0));
-		Assert.assertSame(appframework, list.get(1));
-		Assert.assertSame(kenyaemr, list.get(2));
-		Assert.assertSame(kenyaemr, list.get(3));
+		Assertions.assertSame(uilibrary, list.get(0));
+		Assertions.assertSame(appframework, list.get(1));
+		Assertions.assertSame(kenyaemr, list.get(2));
+		Assertions.assertSame(kenyaemr, list.get(3));
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/module/web/extension/ExtensionUtilTest.java
+++ b/omod/src/test/java/org/openmrs/module/web/extension/ExtensionUtilTest.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.module.web.extension;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -21,7 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/omod/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormControllerTest.java
@@ -9,8 +9,8 @@
  */
 package org.openmrs.scheduler.web.controller;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -19,15 +19,15 @@ import java.util.Date;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.Task;
 import org.openmrs.scheduler.TaskDefinition;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -56,7 +56,7 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 	// in applicationContext-service.xml at the time of coding (Jan 2013)
 	private SchedulerService service;
 	
-	@Before
+	@BeforeEach
 	public void setUpSchedulerService() throws Exception {
 		executeDataSet(INITIAL_SCHEDULER_TASK_CONFIG_XML);
 		
@@ -86,7 +86,7 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertNotSame(oldTaskInstance, task.getTaskInstance());
+		Assertions.assertNotSame(oldTaskInstance, task.getTaskInstance());
 	}
 	
 	/**
@@ -106,7 +106,7 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertSame(oldTaskInstance, task.getTaskInstance());
+		Assertions.assertSame(oldTaskInstance, task.getTaskInstance());
 	}
 	
 	/**
@@ -126,7 +126,7 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertSame(oldTaskInstance, task.getTaskInstance());
+		Assertions.assertSame(oldTaskInstance, task.getTaskInstance());
 	}
 	
 	/**
@@ -148,7 +148,7 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertSame(oldTaskInstance, task.getTaskInstance());
+		Assertions.assertSame(oldTaskInstance, task.getTaskInstance());
 		deleteAllData();
 	}
 	
@@ -167,9 +167,9 @@ public class SchedulerFormControllerTest extends BaseModuleWebContextSensitiveTe
 		
 		ModelAndView mav = controller.handleRequest(mockRequest, new MockHttpServletResponse());
 		assertNotNull(mav);
-		Assert.assertNotNull(task.getRepeatInterval());
+		Assertions.assertNotNull(task.getRepeatInterval());
 		Long interval = 0L;
-		Assert.assertEquals(interval, task.getRepeatInterval());
+		Assertions.assertEquals(interval, task.getRepeatInterval());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormTest.java
+++ b/omod/src/test/java/org/openmrs/scheduler/web/controller/SchedulerFormTest.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.scheduler.web.controller;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.junit.Test;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.junit.jupiter.api.Test;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/omod/src/test/java/org/openmrs/scheduler/web/controller/TaskHelperTest.java
+++ b/omod/src/test/java/org/openmrs/scheduler/web/controller/TaskHelperTest.java
@@ -13,14 +13,14 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.scheduler.SchedulerException;
 import org.openmrs.scheduler.SchedulerService;
 import org.openmrs.scheduler.TaskDefinition;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -32,7 +32,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	
 	private TaskHelper taskHelper;
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		executeDataSet(INITIAL_SCHEDULER_TASK_CONFIG_XML);
 		
@@ -47,7 +47,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	@Test
 	public void getTime_shouldGetATimeInTheFuture() throws Exception {
 		Date then = taskHelper.getTime(Calendar.SECOND, 123);
-		Assert.assertTrue(then.after(new Date()));
+		Assertions.assertTrue(then.after(new Date()));
 	}
 	
 	/**
@@ -57,7 +57,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	@Test
 	public void getTime_shouldGetATimeInThePast() throws Exception {
 		Date then = taskHelper.getTime(Calendar.SECOND, -123);
-		Assert.assertTrue(then.before(new Date()));
+		Assertions.assertTrue(then.before(new Date()));
 	}
 	
 	/**
@@ -68,7 +68,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	public void getScheduledTaskDefinition_shouldReturnATaskThatHasBeenStarted() throws Exception {
 		Date time = taskHelper.getTime(Calendar.SECOND, 1);
 		TaskDefinition task = taskHelper.getScheduledTaskDefinition(time);
-		Assert.assertTrue(task.getStarted());
+		Assertions.assertTrue(task.getStarted());
 	}
 	
 	/**
@@ -79,7 +79,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	public void getUnscheduledTaskDefinition_shouldReturnATaskThatHasNotBeenStarted() throws Exception {
 		Date time = taskHelper.getTime(Calendar.SECOND, 1);
 		TaskDefinition task = taskHelper.getUnscheduledTaskDefinition(time);
-		Assert.assertFalse(task.getStarted());
+		Assertions.assertFalse(task.getStarted());
 	}
 	
 	/**
@@ -92,7 +92,7 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 		TaskDefinition task = taskHelper.getScheduledTaskDefinition(time);
 		taskHelper.waitUntilTaskIsExecuting(task, MAX_WAIT_TIME_IN_MILLISECONDS);
 		
-		Assert.assertTrue(task.getTaskInstance().isExecuting());
+		Assertions.assertTrue(task.getTaskInstance().isExecuting());
 		deleteAllData();
 	}
 	
@@ -100,11 +100,13 @@ public class TaskHelperTest extends BaseModuleWebContextSensitiveTest {
 	 * @verifies raise a timeout exception when the timeout is exceeded
 	 * @see TaskHelper#waitUntilTaskIsExecuting(org.openmrs.scheduler.TaskDefinition, long)
 	 */
-	@Test(expected = TimeoutException.class)
+	@Test
 	public void waitUntilTaskIsExecuting_shouldRaiseATimeoutExceptionWhenTheTimeoutIsExceeded() throws SchedulerException,
-	        TimeoutException, InterruptedException {
-		Date time = taskHelper.getTime(Calendar.MINUTE, 1);
-		TaskDefinition task = taskHelper.getScheduledTaskDefinition(time);
-		taskHelper.waitUntilTaskIsExecuting(task, 10);
+	        InterruptedException {
+		Assertions.assertThrows(TimeoutException.class, () -> {
+			Date time = taskHelper.getTime(Calendar.MINUTE, 1);
+			TaskDefinition task = taskHelper.getScheduledTaskDefinition(time);
+			taskHelper.waitUntilTaskIsExecuting(task, 10);
+		});
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/attribute/handler/BaseMetadataFieldGenDatatypeHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/web/attribute/handler/BaseMetadataFieldGenDatatypeHandlerTest.java
@@ -9,14 +9,14 @@
  */
 package org.openmrs.web.attribute.handler;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Location;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.datatype.MockLocationDatatype;

--- a/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.web.attribute.handler;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -68,7 +69,7 @@ public class RegexValidatedTextDatatypeHandlerTest {
 		
 		InvalidCustomValueException ex = org.junit.jupiter.api.Assertions.assertThrows(InvalidCustomValueException.class,
 			() -> handler.getValue(datatype, request, fieldName));
-		assertThat(ex.getMessage(), is("Invalid value: " + invalidFieldValue));
+		assertThat(ex.getMessage(), containsString("Invalid value: " + invalidFieldValue));
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/web/attribute/handler/RegexValidatedTextDatatypeHandlerTest.java
@@ -10,15 +10,13 @@
 package org.openmrs.web.attribute.handler;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
 import org.openmrs.customdatatype.CustomDatatype;
 import org.openmrs.customdatatype.InvalidCustomValueException;
 import org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype;
@@ -28,9 +26,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
  * Tests {@code RegexValidatedTextDatatypeHandler}.
  */
 public class RegexValidatedTextDatatypeHandlerTest {
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 	
 	private final RegexValidatedTextDatatypeHandler handler = new RegexValidatedTextDatatypeHandler();
 	
@@ -71,9 +66,9 @@ public class RegexValidatedTextDatatypeHandlerTest {
 		RegexValidatedTextDatatype datatype = new RegexValidatedTextDatatype();
 		datatype.setConfiguration("^[012]$");
 		
-		expectedException.expect(InvalidCustomValueException.class);
-		expectedException.expectMessage("Invalid value: " + invalidFieldValue);
-		handler.getValue(datatype, request, fieldName);
+		InvalidCustomValueException ex = org.junit.jupiter.api.Assertions.assertThrows(InvalidCustomValueException.class,
+			() -> handler.getValue(datatype, request, fieldName));
+		assertThat(ex.getMessage(), is("Invalid value: " + invalidFieldValue));
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/web/attribute/handler/SerializingFieldGenDatatypeHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/web/attribute/handler/SerializingFieldGenDatatypeHandlerTest.java
@@ -9,15 +9,15 @@
  */
 package org.openmrs.web.attribute.handler;
 
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.Location;
 import org.openmrs.Program;
@@ -28,7 +28,7 @@ import org.openmrs.customdatatype.datatype.LocationDatatype;
 import org.openmrs.customdatatype.datatype.MockLocationDatatype;
 import org.openmrs.customdatatype.datatype.ProgramDatatype;
 import org.openmrs.customdatatype.datatype.ProviderDatatype;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 public class SerializingFieldGenDatatypeHandlerTest extends BaseModuleWebContextSensitiveTest {
@@ -48,7 +48,7 @@ public class SerializingFieldGenDatatypeHandlerTest extends BaseModuleWebContext
 		MockLocationDatatype datatype = mock(MockLocationDatatype.class);
 		when(datatype.deserialize(eq(locationUuid))).thenReturn(expectedLocation);
 		SerializingFieldGenDatatypeHandler handler = new MockLocationFieldGenDatatypeHandler();
-		Assert.assertEquals(expectedLocation, handler.getValue(datatype, request, formFieldName));
+		Assertions.assertEquals(expectedLocation, handler.getValue(datatype, request, formFieldName));
 	}
 	
 	@Test
@@ -58,10 +58,8 @@ public class SerializingFieldGenDatatypeHandlerTest extends BaseModuleWebContext
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setParameter(formFieldName, locationUuid);
 		MockLocationDatatype datatype = mock(MockLocationDatatype.class);
-		Location expectedLocation = mock(Location.class);
-		when(datatype.deserialize(eq(locationUuid))).thenReturn(expectedLocation);
 		SerializingFieldGenDatatypeHandler handler = new MockLocationFieldGenDatatypeHandler();
-		Assert.assertNull(handler.getValue(datatype, request, formFieldName));
+		Assertions.assertNull(handler.getValue(datatype, request, formFieldName));
 	}
 	
 	@Test

--- a/omod/src/test/java/org/openmrs/web/controller/ConceptFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ConceptFormControllerTest.java
@@ -145,7 +145,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		// send the parameters to the controller
 		ModelAndView mav = controller.handleRequest(request, response);
 		
-		Assertions.assertNotSame("The purge attempt should have failed!", "index.htm", mav.getViewName());
+		Assertions.assertNotSame("index.htm", mav.getViewName(), "The purge attempt should have failed!");
 		Assertions.assertNotNull(cs.getConcept(3));
 		
 	}

--- a/omod/src/test/java/org/openmrs/web/controller/ConceptFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ConceptFormControllerTest.java
@@ -13,11 +13,11 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -25,9 +25,9 @@ import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptAnswer;
 import org.openmrs.ConceptAttribute;
@@ -49,7 +49,7 @@ import org.openmrs.test.Verifies;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.web.controller.ConceptFormController.ConceptFormBackingObject;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.openmrs.web.test.WebTestHelper;
 import org.openmrs.web.test.WebTestHelper.Response;
 import org.springframework.beans.factory.ObjectFactory;
@@ -81,7 +81,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 	
 	protected static final String CONCEPT_ATTRIBUTES_XML = "org/openmrs/api/include/ConceptServiceTest-conceptAttributeType.xml";
 	
-	@Before
+	@BeforeEach
 	public void updateSearchIndex() {
 		super.updateSearchIndex();
 		if (britishEn == null) {
@@ -108,7 +108,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		
 		// make sure there is an "conceptId" filled in on the concept
 		ConceptFormBackingObject command = (ConceptFormBackingObject) modelAndView.getModel().get("command");
-		Assert.assertNotNull(command.getConcept().getConceptId());
+		Assertions.assertNotNull(command.getConcept().getConceptId());
 		
 	}
 	
@@ -145,8 +145,8 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		// send the parameters to the controller
 		ModelAndView mav = controller.handleRequest(request, response);
 		
-		Assert.assertNotSame("The purge attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotNull(cs.getConcept(3));
+		Assertions.assertNotSame("The purge attempt should have failed!", "index.htm", mav.getViewName());
+		Assertions.assertNotNull(cs.getConcept(3));
 		
 	}
 	
@@ -652,12 +652,12 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		assertTrue(mav.getModel().isEmpty());
 		
 		ConceptNumeric concept = (ConceptNumeric) cs.getConcept(5089);
-		Assert.assertEquals(EXPECTED_LOW_NORMAL, concept.getLowNormal());
-		Assert.assertEquals(EXPECTED_HI_NORMAL, concept.getHiNormal());
-		Assert.assertEquals(EXPECTED_LOW_ABSOLUTE, concept.getLowAbsolute());
-		Assert.assertEquals(EXPECTED_HI_ABSOLUTE, concept.getHiAbsolute());
-		Assert.assertEquals(EXPECTED_LOW_CRITICAL, concept.getLowCritical());
-		Assert.assertEquals(EXPECTED_HI_CRITICAL, concept.getHiCritical());
+		Assertions.assertEquals(EXPECTED_LOW_NORMAL, concept.getLowNormal());
+		Assertions.assertEquals(EXPECTED_HI_NORMAL, concept.getHiNormal());
+		Assertions.assertEquals(EXPECTED_LOW_ABSOLUTE, concept.getLowAbsolute());
+		Assertions.assertEquals(EXPECTED_HI_ABSOLUTE, concept.getHiAbsolute());
+		Assertions.assertEquals(EXPECTED_LOW_CRITICAL, concept.getLowCritical());
+		Assertions.assertEquals(EXPECTED_HI_CRITICAL, concept.getHiCritical());
 	}
 	
 	/**
@@ -684,12 +684,12 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		assertNotNull(mav);
 		ConceptFormBackingObject formBackingObject = (ConceptFormBackingObject) mav.getModel().get("command");
 		
-		Assert.assertEquals(EXPECTED_LOW_NORMAL, formBackingObject.getLowNormal());
-		Assert.assertEquals(EXPECTED_HI_NORMAL, formBackingObject.getHiNormal());
-		Assert.assertEquals(EXPECTED_LOW_ABSOLUTE, formBackingObject.getLowAbsolute());
-		Assert.assertEquals(EXPECTED_HI_ABSOLUTE, formBackingObject.getHiAbsolute());
-		Assert.assertEquals(EXPECTED_LOW_CRITICAL, formBackingObject.getLowCritical());
-		Assert.assertEquals(EXPECTED_HI_CRITICAL, formBackingObject.getHiCritical());
+		Assertions.assertEquals(EXPECTED_LOW_NORMAL, formBackingObject.getLowNormal());
+		Assertions.assertEquals(EXPECTED_HI_NORMAL, formBackingObject.getHiNormal());
+		Assertions.assertEquals(EXPECTED_LOW_ABSOLUTE, formBackingObject.getLowAbsolute());
+		Assertions.assertEquals(EXPECTED_HI_ABSOLUTE, formBackingObject.getHiAbsolute());
+		Assertions.assertEquals(EXPECTED_LOW_CRITICAL, formBackingObject.getLowCritical());
+		Assertions.assertEquals(EXPECTED_HI_CRITICAL, formBackingObject.getHiCritical());
 	}
 	
 	/**
@@ -840,7 +840,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		ConceptService cs = Context.getConceptService();
 		Concept concept = cs.getConcept(5497);
 		//sanity check, the current preferred Name should be different from what will get set in the form
-		Assert.assertNotSame("CD3+CD4+ABS CNT", concept.getPreferredName(britishEn).getName());
+		Assertions.assertNotSame("CD3+CD4+ABS CNT", concept.getPreferredName(britishEn).getName());
 		
 		ConceptFormController conceptFormController =  conceptFormProvider.getObject();
 		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
@@ -853,9 +853,9 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertEquals("CD3+CD4+ABS CNT", concept.getPreferredName(britishEn).getName());
+		Assertions.assertEquals("CD3+CD4+ABS CNT", concept.getPreferredName(britishEn).getName());
 		//preferred name should be the new one that has been set from the form
-		Assert.assertEquals(true, concept.getPreferredName(britishEn).isLocalePreferred());
+		Assertions.assertEquals(true, concept.getPreferredName(britishEn).isLocalePreferred());
 	}
 	
 	/**
@@ -884,7 +884,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertEquals(true, preferredName.isVoided());
+		Assertions.assertEquals(true, preferredName.isVoided());
 	}
 	
 	/**
@@ -950,7 +950,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		
 		Concept createdConcept = cs.getConceptByName(conceptName);
 		assertNotNull(createdConcept);
-		Assert.assertEquals(1, createdConcept.getConceptMappings().size());
+		Assertions.assertEquals(1, createdConcept.getConceptMappings().size());
 	}
 	
 	/**
@@ -1032,8 +1032,8 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		concept.addConceptMapping(new ConceptMap(term, new ConceptMapType(1)));
 		BindException errors = new BindException(concept, "concept");
 		new ConceptFormController().validateConceptUsesPersistedObjects(concept, errors);
-		Assert.assertEquals(1, errors.getErrorCount());
-		Assert.assertEquals(true,
+		Assertions.assertEquals(1, errors.getErrorCount());
+		Assertions.assertEquals(true,
 		    errors.hasFieldErrors("conceptMappings[0].conceptReferenceTerm.conceptReferenceTermMaps[0].conceptMapType"));
 	}
 	
@@ -1052,8 +1052,8 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		concept.addConceptMapping(new ConceptMap(term, new ConceptMapType(1)));
 		BindException errors = new BindException(concept, "concept");
 		new ConceptFormController().validateConceptUsesPersistedObjects(concept, errors);
-		Assert.assertEquals(1, errors.getErrorCount());
-		Assert.assertEquals(true, errors.hasFieldErrors("conceptMappings[0].conceptReferenceTerm.conceptSource"));
+		Assertions.assertEquals(1, errors.getErrorCount());
+		Assertions.assertEquals(true, errors.hasFieldErrors("conceptMappings[0].conceptReferenceTerm.conceptSource"));
 	}
 	
 	/**
@@ -1071,8 +1071,8 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		concept.addConceptMapping(new ConceptMap(term, new ConceptMapType(1)));
 		BindException errors = new BindException(concept, "concept");
 		new ConceptFormController().validateConceptUsesPersistedObjects(concept, errors);
-		Assert.assertEquals(1, errors.getErrorCount());
-		Assert.assertEquals(true,
+		Assertions.assertEquals(1, errors.getErrorCount());
+		Assertions.assertEquals(true,
 		    errors.hasFieldErrors("conceptMappings[0].conceptReferenceTerm.conceptReferenceTermMaps[0].termB"));
 	}
 	
@@ -1304,9 +1304,9 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		ConceptFormController conceptFormController =  conceptFormProvider.getObject();
 		conceptFormController.handleRequest(mockHttpServletRequest, new MockHttpServletResponse());
 		
-		Assert.assertEquals(1, concept.getAttributes().size());
-		Assert.assertFalse(((ConceptAttribute) (concept.getAttributes().toArray()[0])).getVoided());
-		Assert.assertFalse(errors.hasErrors());
+		Assertions.assertEquals(1, concept.getAttributes().size());
+		Assertions.assertFalse(((ConceptAttribute) (concept.getAttributes().toArray()[0])).getVoided());
+		Assertions.assertFalse(errors.hasErrors());
 	}
 	
 	/**
@@ -1331,9 +1331,9 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		ConceptFormController conceptFormController =  conceptFormProvider.getObject();
 		conceptFormController.handleRequest(mockHttpServletRequest, new MockHttpServletResponse());
 		
-		Assert.assertEquals(1, concept.getAttributes().size());
-		Assert.assertTrue(((ConceptAttribute) (concept.getAttributes().toArray()[0])).getVoided());
-		Assert.assertFalse(errors.hasErrors());
+		Assertions.assertEquals(1, concept.getAttributes().size());
+		Assertions.assertTrue(((ConceptAttribute) (concept.getAttributes().toArray()[0])).getVoided());
+		Assertions.assertFalse(errors.hasErrors());
 	}
 	
 	/**
@@ -1381,7 +1381,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 	 *       Class.forName("org.openmrs.ConceptReferenceRange"); Method getReferenceRangesMethod =
 	 *       ConceptNumeric.class.getMethod("getReferenceRanges", referenceRangeClass); Set
 	 *       listOfReferenceRanges = (Set) getReferenceRangesMethod.invoke(createdConcept, null);
-	 *       Assert.assertEquals(1, listOfReferenceRanges.size()); } // /** // * @see
+	 *       Assertions.assertEquals(1, listOfReferenceRanges.size()); } // /** // * @see
 	 *       ConceptFormController#onSubmit(HttpServletRequest, HttpServletResponse, Object, // *
 	 *       BindException) // /
 	 * @Test public void onSubmit_shouldIgnoreNewConceptReferenceRowIfTheUserDidNotEnterAnyData()
@@ -1430,7 +1430,7 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 	 *       updateConceptReferenceRange(referenceRange, conceptNumeric); BindException errors = new
 	 *       BindException(conceptNumeric, "conceptNumeric"); new
 	 *       ConceptFormValidator().validateConceptReferenceRange(conceptNumeric, errors);
-	 *       Assert.assertEquals(1, errors.getErrorCount());
+	 *       Assertions.assertEquals(1, errors.getErrorCount());
 	 *       assertTrue(errors.hasFieldErrors("referenceRanges[0].hiAbsolute"));
 	 *       assertTrue(errors.hasFieldErrors("referenceRanges[0].lowAbsolute")); } private void
 	 *       updateConceptReferenceRange( ConceptReferenceRange webReferenceRange, ConceptNumeric

--- a/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/ForgotPasswordFormControllerTest.java
@@ -14,12 +14,12 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
@@ -33,7 +33,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 	
 	protected static final String TEST_DATA = "org/openmrs/web/controller/include/ForgotPasswordFormControllerTest.xml";
 	
-	@Before
+	@BeforeEach
 	public void runBeforeEachTest() throws Exception {
 		executeDataSet(TEST_DATA);
 		Context.logout();
@@ -58,7 +58,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		
 		controller.handleRequest(request, response);
 		
-		Assert.assertEquals("invaliduser", request.getAttribute("uname"));
+		Assertions.assertEquals("invaliduser", request.getAttribute("uname"));
 		
 		List<String> questions = new ArrayList<String>();
 		
@@ -71,7 +71,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		questions.add(Context.getMessageSourceService().getMessage("Which city were you born in?"));
 		
 		//Check that one of the fake questions is assigned to the invalid username
-		Assert.assertTrue(questions.contains(request.getAttribute("secretQuestion")));
+		Assertions.assertTrue(questions.contains(request.getAttribute("secretQuestion")));
 	}
 	
 	@Test
@@ -87,8 +87,8 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		
 		HttpServletResponse response = new MockHttpServletResponse();
 		ModelAndView mv = controller.handleRequest(request, response);
-		Assert.assertEquals("/options.form#Change Login Info", ((RedirectView) mv.getView()).getUrl());
-		Assert.assertEquals(2, Context.getAuthenticatedUser().getId().intValue());
+		Assertions.assertEquals("/options.form#Change Login Info", ((RedirectView) mv.getView()).getUrl());
+		Assertions.assertEquals(2, Context.getAuthenticatedUser().getId().intValue());
 	}
 	
 	/**
@@ -109,10 +109,10 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		
 		HttpServletResponse response = new MockHttpServletResponse();
 		controller.handleRequest(request, response);
-		Assert.assertEquals("valid secret question", request.getAttribute("secretQuestion"));
-		Assert.assertEquals("auth.answer.invalid", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
-		Assert.assertEquals("auth.question.fill", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
-		Assert.assertFalse(Context.isAuthenticated());
+		Assertions.assertEquals("valid secret question", request.getAttribute("secretQuestion"));
+		Assertions.assertEquals("auth.answer.invalid", request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
+		Assertions.assertEquals("auth.question.fill", request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		Assertions.assertFalse(Context.isAuthenticated());
 	}
 	
 	/**
@@ -141,7 +141,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		request.addParameter("uname", "validuser");
 		
 		controller.handleRequest(request, new MockHttpServletResponse());
-		Assert.assertNull(request.getAttribute("secretQuestion"));
+		Assertions.assertNull(request.getAttribute("secretQuestion"));
 	}
 	
 	/**
@@ -172,7 +172,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		request.addParameter("secretAnswer", "valid secret answer");
 		controller.handleRequest(request, new MockHttpServletResponse());
 		
-		Assert.assertFalse(Context.isAuthenticated());
+		Assertions.assertFalse(Context.isAuthenticated());
 	}
 	
 	/**
@@ -205,7 +205,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		
 		controller.handleRequest(request, new MockHttpServletResponse());
 		
-		Assert.assertFalse(Context.isAuthenticated());
+		Assertions.assertFalse(Context.isAuthenticated());
 	}
 	
 	/**
@@ -235,7 +235,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		
 		controller.handleRequest(request, new MockHttpServletResponse());
 		
-		Assert.assertNotNull(request.getAttribute("secretQuestion"));
+		Assertions.assertNotNull(request.getAttribute("secretQuestion"));
 		
 		// now the user has 5 chances at the secret answer
 		
@@ -246,7 +246,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		request5.addParameter("uname", "validuser");
 		request5.addParameter("secretAnswer", "invalid answer");
 		controller.handleRequest(request5, new MockHttpServletResponse());
-		Assert.assertNotNull(request5.getAttribute("secretQuestion"));
+		Assertions.assertNotNull(request5.getAttribute("secretQuestion"));
 		
 		// sixth request (should not lock out because is after valid username)
 		MockHttpServletRequest request6 = new MockHttpServletRequest();
@@ -256,7 +256,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		request6.addParameter("secretAnswer", "invalid answer");
 		request.setMethod("POST");
 		controller.handleRequest(request6, new MockHttpServletResponse());
-		Assert.assertNotNull(request6.getAttribute("secretQuestion"));
+		Assertions.assertNotNull(request6.getAttribute("secretQuestion"));
 		
 		// seventh request (should Accept with valid answer)
 		MockHttpServletRequest request7 = new MockHttpServletRequest();
@@ -266,7 +266,7 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		request7.addParameter("secretAnswer", "valid secret answer");
 		controller.handleRequest(request7, new MockHttpServletResponse());
 		
-		Assert.assertTrue(Context.isAuthenticated());
+		Assertions.assertTrue(Context.isAuthenticated());
 	}
 	
 	@Test
@@ -280,6 +280,6 @@ public class ForgotPasswordFormControllerTest extends BaseModuleWebContextSensit
 		HttpServletResponse response = new MockHttpServletResponse();
 		
 		controller.handleRequest(request, response);
-		Assert.assertFalse(Context.isAuthenticated());
+		Assertions.assertFalse(Context.isAuthenticated());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/GlobalPropertyPortletControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/GlobalPropertyPortletControllerTest.java
@@ -16,13 +16,13 @@ import java.util.Map;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 public class GlobalPropertyPortletControllerTest extends BaseModuleWebContextSensitiveTest {
@@ -49,9 +49,9 @@ public class GlobalPropertyPortletControllerTest extends BaseModuleWebContextSen
 		//then
 		portletController.populateModel(request, model);
 		List<GlobalProperty> properties = (List<GlobalProperty>) model.get("properties");
-		Assert.assertFalse(properties.contains(globalProperties[0]));
-		Assert.assertFalse(properties.contains(globalProperties[1]));
-		Assert.assertTrue(properties.contains(globalProperties[2]));
+		Assertions.assertFalse(properties.contains(globalProperties[0]));
+		Assertions.assertFalse(properties.contains(globalProperties[1]));
+		Assertions.assertTrue(properties.contains(globalProperties[2]));
 	}
 	
 	/**
@@ -70,9 +70,9 @@ public class GlobalPropertyPortletControllerTest extends BaseModuleWebContextSen
 		
 		//then
 		portletController.setupModelForModule(model);
-		Assert.assertEquals(forModule + ".", model.get("propertyPrefix"));
-		Assert.assertEquals("true", model.get("hidePrefix"));
-		Assert.assertEquals(forModule + ".started;" + forModule + ".mandatory", model.get("excludePrefix"));
+		Assertions.assertEquals(forModule + ".", model.get("propertyPrefix"));
+		Assertions.assertEquals("true", model.get("hidePrefix"));
+		Assertions.assertEquals(forModule + ".started;" + forModule + ".mandatory", model.get("excludePrefix"));
 	}
 	
 	/**
@@ -89,9 +89,9 @@ public class GlobalPropertyPortletControllerTest extends BaseModuleWebContextSen
 		
 		//then
 		portletController.setupModelForModule(model);
-		Assert.assertNull(model.get("propertyPrefix"));
-		Assert.assertNull(model.get("hidePrefix"));
-		Assert.assertNull(model.get("excludePrefix"));
+		Assertions.assertNull(model.get("propertyPrefix"));
+		Assertions.assertNull(model.get("hidePrefix"));
+		Assertions.assertNull(model.get("excludePrefix"));
 	}
 	
 	/**
@@ -112,7 +112,7 @@ public class GlobalPropertyPortletControllerTest extends BaseModuleWebContextSen
 		
 		//then
 		portletController.setupModelForModule(model);
-		Assert.assertEquals(excludePrefix + ";" + forModule + ".started;" + forModule + ".mandatory",
+		Assertions.assertEquals(excludePrefix + ";" + forModule + ".started;" + forModule + ".mandatory",
 		    model.get("excludePrefix"));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/LoginControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/LoginControllerTest.java
@@ -9,16 +9,16 @@
  */
 package org.openmrs.web.controller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  *

--- a/omod/src/test/java/org/openmrs/web/controller/OptionsFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/OptionsFormControllerTest.java
@@ -11,15 +11,16 @@ package org.openmrs.web.controller;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.net.BindException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openmrs.GlobalProperty;
@@ -145,7 +146,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		testHelper.handle(post);
 		
 		//then
-		Assert.assertThat("ab@gmail.com", is(Context.getAuthenticatedUser().getUsername()));
+		MatcherAssert.assertThat("ab@gmail.com", is(Context.getAuthenticatedUser().getUsername()));
 	}
 	
 	/**
@@ -164,7 +165,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		testHelper.handle(post);
 		
 		//then
-		Assert.assertThat("ab@", is(not(Context.getAuthenticatedUser().getUsername())));
+		MatcherAssert.assertThat("ab@", is(not(Context.getAuthenticatedUser().getUsername())));
 	}
 	
 	/**
@@ -181,7 +182,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		testHelper.handle(post);
 		
 		//then
-		Assert.assertThat("ab", is(Context.getAuthenticatedUser().getUsername()));
+		MatcherAssert.assertThat("ab", is(Context.getAuthenticatedUser().getUsername()));
 	}
 	
 	/**
@@ -198,7 +199,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		testHelper.handle(post);
 		
 		//then
-		Assert.assertThat("a", is(not(Context.getAuthenticatedUser().getUsername())));
+		MatcherAssert.assertThat("a", is(not(Context.getAuthenticatedUser().getUsername())));
 	}
 	
 	@Test
@@ -216,7 +217,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		
 		BeanPropertyBindingResult bindingResult = (BeanPropertyBindingResult) modelAndView.getModel().get(
 		    "org.springframework.validation.BindingResult.opts");
-		Assert.assertTrue(bindingResult.hasErrors());
+		Assertions.assertTrue(bindingResult.hasErrors());
 	}
 	
 	@Test
@@ -248,7 +249,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		
 		BeanPropertyBindingResult bindingResult = (BeanPropertyBindingResult) modelAndView.getModel().get(
 		    "org.springframework.validation.BindingResult.opts");
-		Assert.assertTrue(bindingResult.hasErrors());
+		Assertions.assertTrue(bindingResult.hasErrors());
 	}
 	
 	@Test
@@ -263,9 +264,9 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 		request.setParameter("secretAnswerConfirm", "easy answer");
 		
 		controller.handleRequest(request, response);
-		Assert.assertEquals("easy question", loginCredential.getSecretQuestion());
+		Assertions.assertEquals("easy question", loginCredential.getSecretQuestion());
 		String hashedAnswer = Security.encodeString("easy answer" + loginCredential.getSalt());
-		Assert.assertEquals(hashedAnswer, loginCredential.getSecretAnswer());
+		Assertions.assertEquals(hashedAnswer, loginCredential.getSecretAnswer());
 		String oldPassword = loginCredential.getHashedPassword();
 		
 		request.removeAllParameters();
@@ -279,7 +280,7 @@ public class OptionsFormControllerTest extends BaseModuleWebContextSensitiveTest
 			request.setParameter("secretQuestionNew", "");
 			mav = controller.handleRequest(request, response);
 		}
-		Assert.assertEquals(hashedAnswer, loginCredential.getSecretAnswer());
-		Assert.assertEquals("easy question", loginCredential.getSecretQuestion());
+		Assertions.assertEquals(hashedAnswer, loginCredential.getSecretAnswer());
+		Assertions.assertEquals("easy question", loginCredential.getSecretQuestion());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/PortletControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/PortletControllerTest.java
@@ -15,11 +15,11 @@ import java.util.Map;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
@@ -59,7 +59,7 @@ public class PortletControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void handleRequest_shouldCalculateBmiIntoPatientBmiAsString() throws Exception {
 		executeDataSet("org/openmrs/web/controller/include/PortletControllerTest-bmi.xml");
 		Map<String, Object> modelmap = getModelFromController(7);
-		Assert.assertEquals("61.7", modelmap.get("patientBmiAsString"));
+		Assertions.assertEquals("61.7", modelmap.get("patientBmiAsString"));
 	}
 	
 	/**
@@ -69,6 +69,6 @@ public class PortletControllerTest extends BaseModuleWebContextSensitiveTest {
 	@Verifies(value = "should not fail with empty height and weight properties", method = "handleRequest(HttpServletRequest,HttpServletResponse)")
 	public void handleRequest_shouldNotFailWithEmptyHeightAndWeightProperties() throws Exception {
 		Map<String, Object> modelmap = getModelFromController(7);
-		Assert.assertEquals("?", modelmap.get("patientBmiAsString"));
+		Assertions.assertEquals("?", modelmap.get("patientBmiAsString"));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/UserPropertiesTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/UserPropertiesTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.web.controller;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.User;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptDrugFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptDrugFormControllerTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.web.controller.concept;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;
@@ -37,7 +37,7 @@ public class ConceptDrugFormControllerTest extends BaseModuleWebContextSensitive
 		
 		Integer drugId = new Integer(444);
 		Drug drug = service.getDrug(drugId);
-		org.junit.Assert.assertEquals(drugId, drug.getDrugId());
+		org.junit.jupiter.api.Assertions.assertEquals(drugId, drug.getDrugId());
 		
 		MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
 		MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
@@ -46,6 +46,6 @@ public class ConceptDrugFormControllerTest extends BaseModuleWebContextSensitive
 		
 		controller.onSubmit(mockHttpServletRequest, mockHttpServletResponse, drug, errors);
 		Context.flushSession();
-		org.junit.Assert.assertNull(service.getDrug(drugId));
+		org.junit.jupiter.api.Assertions.assertNull(service.getDrug(drugId));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptFormControllerTest.java
@@ -11,19 +11,18 @@ package org.openmrs.web.controller.concept;
 
 import java.util.ArrayList;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.openmrs.ConceptMap;
 import org.openmrs.ConceptNumeric;
 import org.openmrs.web.controller.ConceptFormController;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest {
 	
 	@Test
 	public void ConceptFormBackingObject_shouldCopyNumericAttributes() {
 		ConceptNumeric concept = Mockito.mock(ConceptNumeric.class);
-		Mockito.when(concept.isNumeric()).thenReturn(Boolean.TRUE);
 		Mockito.when(concept.getHiAbsolute()).thenReturn(5.2);
 		Mockito.when(concept.getLowAbsolute()).thenReturn(1.0);
 		
@@ -43,18 +42,18 @@ public class ConceptFormControllerTest extends BaseModuleWebContextSensitiveTest
 		ConceptFormController.ConceptFormBackingObject conceptFormBackingObject = controller.new ConceptFormBackingObject(
 		                                                                                                                  concept);
 		
-		org.junit.Assert.assertEquals(Double.valueOf(5.2), conceptFormBackingObject.getHiAbsolute());
-		org.junit.Assert.assertEquals(Double.valueOf(1.0), conceptFormBackingObject.getLowAbsolute());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(5.2), conceptFormBackingObject.getHiAbsolute());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(1.0), conceptFormBackingObject.getLowAbsolute());
 		
-		org.junit.Assert.assertEquals(Double.valueOf(4.1), conceptFormBackingObject.getHiCritical());
-		org.junit.Assert.assertEquals(Double.valueOf(2.1), conceptFormBackingObject.getLowCritical());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(4.1), conceptFormBackingObject.getHiCritical());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(2.1), conceptFormBackingObject.getLowCritical());
 		
-		org.junit.Assert.assertEquals(Double.valueOf(3.1), conceptFormBackingObject.getLowNormal());
-		org.junit.Assert.assertEquals(Double.valueOf(3.9), conceptFormBackingObject.getHiNormal());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(3.1), conceptFormBackingObject.getLowNormal());
+		org.junit.jupiter.api.Assertions.assertEquals(Double.valueOf(3.9), conceptFormBackingObject.getHiNormal());
 		
-		org.junit.Assert.assertEquals(Integer.valueOf(42), conceptFormBackingObject.getDisplayPrecision());
+		org.junit.jupiter.api.Assertions.assertEquals(Integer.valueOf(42), conceptFormBackingObject.getDisplayPrecision());
 		
-		org.junit.Assert.assertEquals("ml", conceptFormBackingObject.getUnits());
+		org.junit.jupiter.api.Assertions.assertEquals("ml", conceptFormBackingObject.getUnits());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptProposalFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptProposalFormControllerTest.java
@@ -9,8 +9,8 @@
  */
 package org.openmrs.web.controller.concept;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Locale;
@@ -18,16 +18,16 @@ import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptProposal;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -52,12 +52,12 @@ public class ConceptProposalFormControllerTest extends BaseModuleWebContextSensi
 		Concept conceptToMap = cs.getConcept(5);
 		Locale locale = Locale.ENGLISH;
 		//sanity checks
-		Assert.assertFalse(conceptToMap.hasName(cp.getOriginalText(), locale));
-		Assert.assertEquals(0, os.getObservationsByPersonAndConcept(cp.getEncounter().getPatient(), obsConcept).size());
+		Assertions.assertFalse(conceptToMap.hasName(cp.getOriginalText(), locale));
+		Assertions.assertEquals(0, os.getObservationsByPersonAndConcept(cp.getEncounter().getPatient(), obsConcept).size());
 		List<ConceptProposal> proposals = cs.getConceptProposals(cp.getOriginalText());
-		Assert.assertEquals(5, proposals.size());
+		Assertions.assertEquals(5, proposals.size());
 		for (ConceptProposal conceptProposal : proposals) {
-			Assert.assertNull(conceptProposal.getObs());
+			Assertions.assertNull(conceptProposal.getObs());
 		}
 		
 		// set up the controller
@@ -80,16 +80,16 @@ public class ConceptProposalFormControllerTest extends BaseModuleWebContextSensi
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertEquals(cp.getOriginalText(), cp.getFinalText());
-		Assert.assertTrue(conceptToMap.hasName(cp.getOriginalText(), locale));
-		Assert.assertNotNull(cp.getObs());
+		Assertions.assertEquals(cp.getOriginalText(), cp.getFinalText());
+		Assertions.assertTrue(conceptToMap.hasName(cp.getOriginalText(), locale));
+		Assertions.assertNotNull(cp.getObs());
 		//Obs should have been created for the 2 proposals with same text, obsConcept but different encounters
-		Assert.assertEquals(2, os.getObservationsByPersonAndConcept(cp.getEncounter().getPatient(), obsConcept).size());
+		Assertions.assertEquals(2, os.getObservationsByPersonAndConcept(cp.getEncounter().getPatient(), obsConcept).size());
 		
 		//The proposal with a different obs concept should have been skipped
 		proposals = cs.getConceptProposals(cp.getFinalText());
-		Assert.assertEquals(1, proposals.size());
-		Assert.assertEquals(21, proposals.get(0).getObsConcept().getConceptId().intValue());
+		Assertions.assertEquals(1, proposals.size());
+		Assertions.assertEquals(21, proposals.get(0).getObsConcept().getConceptId().intValue());
 	}
 	
 	/**
@@ -107,7 +107,7 @@ public class ConceptProposalFormControllerTest extends BaseModuleWebContextSensi
 		Concept conceptToMap = cs.getConcept(4);
 		Locale locale = new Locale("en", "GB");
 		
-		Assert.assertFalse(conceptToMap.hasName(cp.getOriginalText(), locale));
+		Assertions.assertFalse(conceptToMap.hasName(cp.getOriginalText(), locale));
 		
 		ConceptProposalFormController controller = (ConceptProposalFormController) applicationContext
 		        .getBean("conceptProposalForm");
@@ -128,7 +128,7 @@ public class ConceptProposalFormControllerTest extends BaseModuleWebContextSensi
 		assertNotNull(mav);
 		assertTrue(mav.getModel().isEmpty());
 		
-		Assert.assertEquals(cp.getOriginalText(), cp.getFinalText());
-		Assert.assertTrue(conceptToMap.hasName(cp.getOriginalText(), locale));
+		Assertions.assertEquals(cp.getOriginalText(), cp.getFinalText());
+		Assertions.assertTrue(conceptToMap.hasName(cp.getOriginalText(), locale));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptSourceFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptSourceFormControllerTest.java
@@ -14,13 +14,13 @@ import java.net.BindException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -48,8 +48,8 @@ public class ConceptSourceFormControllerTest extends BaseModuleWebContextSensiti
 		controller.handleRequest(mockRequest, new MockHttpServletResponse());
 		
 		ConceptSource conceptSource = cs.getConceptSource(3);
-		Assert.assertTrue(conceptSource.isRetired());
-		Assert.assertEquals("dummy reason for retirement", conceptSource.getRetireReason());
+		Assertions.assertTrue(conceptSource.isRetired());
+		Assertions.assertEquals("dummy reason for retirement", conceptSource.getRetireReason());
 	}
 	
 	/**
@@ -70,7 +70,7 @@ public class ConceptSourceFormControllerTest extends BaseModuleWebContextSensiti
 		controller.handleRequest(mockRequest, new MockHttpServletResponse());
 		
 		ConceptSource nullConceptSource = cs.getConceptSource(3);
-		Assert.assertNull(nullConceptSource);
+		Assertions.assertNull(nullConceptSource);
 	}
 	
 	/**
@@ -92,8 +92,8 @@ public class ConceptSourceFormControllerTest extends BaseModuleWebContextSensiti
 		controller.handleRequest(mockRequest, new MockHttpServletResponse());
 		
 		ConceptSource conceptSource = cs.getConceptSource(3);
-		Assert.assertTrue(conceptSource.isRetired());
-		Assert.assertEquals("dummy reason for retirement", conceptSource.getRetireReason());
+		Assertions.assertTrue(conceptSource.isRetired());
+		Assertions.assertEquals("dummy reason for retirement", conceptSource.getRetireReason());
 		
 		MockHttpServletRequest restoreMockRequest = new MockHttpServletRequest();
 		restoreMockRequest.setMethod("POST");
@@ -103,7 +103,7 @@ public class ConceptSourceFormControllerTest extends BaseModuleWebContextSensiti
 		controller.handleRequest(restoreMockRequest, new MockHttpServletResponse());
 		
 		ConceptSource newConceptSource = cs.getConceptSource(3);
-		Assert.assertNotNull("Error, Object is null", newConceptSource);
-		Assert.assertTrue(!newConceptSource.isRetired());
+		Assertions.assertNotNull(newConceptSource, "Error, Object is null");
+		Assertions.assertTrue(!newConceptSource.isRetired());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptStopWordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptStopWordFormControllerTest.java
@@ -13,12 +13,12 @@ import java.util.Locale;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.ConceptStopWord;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.validation.BindException;
 import org.springframework.validation.ObjectError;
@@ -45,8 +45,8 @@ public class ConceptStopWordFormControllerTest extends BaseModuleWebContextSensi
 		
 		controller.handleSubmission(mockSession, new ConceptStopWord("As", Locale.ENGLISH), errors);
 		
-		Assert.assertEquals("ConceptStopWord.saved", mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
-		Assert.assertNull(mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
+		Assertions.assertEquals("ConceptStopWord.saved", mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		Assertions.assertNull(mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
 	
 	/**
@@ -69,8 +69,8 @@ public class ConceptStopWordFormControllerTest extends BaseModuleWebContextSensi
 		controller.handleSubmission(mockSession, conceptStopWord, errors);
 		ObjectError objectError = (ObjectError) errors.getAllErrors().get(0);
 		
-		Assert.assertTrue(errors.hasErrors());
-		Assert.assertEquals(1, errors.getErrorCount());
-		Assert.assertEquals("ConceptStopWord.error.value.empty", objectError.getCode());
+		Assertions.assertTrue(errors.hasErrors());
+		Assertions.assertEquals(1, errors.getErrorCount());
+		Assertions.assertEquals("ConceptStopWord.error.value.empty", objectError.getCode());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/concept/ConceptStopWordListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/concept/ConceptStopWordListControllerTest.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.ConceptStopWord;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 
@@ -41,8 +41,8 @@ public class ConceptStopWordListControllerTest extends BaseModuleWebContextSensi
 		
 		String showFormResult = controller.showForm(mockRequest.getSession());
 		
-		Assert.assertNotNull(showFormResult);
-		Assert.assertEquals("admin/concepts/conceptStopWordList", showFormResult);
+		Assertions.assertNotNull(showFormResult);
+		Assertions.assertEquals("admin/concepts/conceptStopWordList", showFormResult);
 	}
 	
 	/**
@@ -62,8 +62,8 @@ public class ConceptStopWordListControllerTest extends BaseModuleWebContextSensi
 		
 		List<ConceptStopWord> conceptStopWordList = (List<ConceptStopWord>) mockRequest.getSession().getAttribute(
 		    "conceptStopWordList");
-		Assert.assertNotNull(conceptStopWordList);
-		Assert.assertEquals(4, conceptStopWordList.size());
+		Assertions.assertNotNull(conceptStopWordList);
+		Assertions.assertEquals(4, conceptStopWordList.size());
 	}
 	
 	/**
@@ -82,8 +82,8 @@ public class ConceptStopWordListControllerTest extends BaseModuleWebContextSensi
 		controller.handleSubmission(mockSession, new String[] { "1" });
 		
 		List<ConceptStopWord> conceptStopWordList = (List<ConceptStopWord>) mockSession.getAttribute("conceptStopWordList");
-		Assert.assertNotNull(conceptStopWordList);
-		Assert.assertEquals(3, conceptStopWordList.size());
+		Assertions.assertNotNull(conceptStopWordList);
+		Assertions.assertEquals(3, conceptStopWordList.size());
 	}
 	
 	/**
@@ -103,9 +103,9 @@ public class ConceptStopWordListControllerTest extends BaseModuleWebContextSensi
 		String successMessage = (String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR);
 		String errorMessage = (String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR);
 		
-		Assert.assertNotNull(successMessage);
-		Assert.assertNull(errorMessage);
-		Assert.assertEquals("general.deleted", successMessage);
+		Assertions.assertNotNull(successMessage);
+		Assertions.assertNull(errorMessage);
+		Assertions.assertEquals("general.deleted", successMessage);
 	}
 	
 	/**
@@ -125,8 +125,8 @@ public class ConceptStopWordListControllerTest extends BaseModuleWebContextSensi
 		String successMessage = (String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR);
 		String errorMessage = (String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR);
 		
-		Assert.assertNotNull(successMessage);
-		Assert.assertNotNull(errorMessage);
-		Assert.assertEquals("ConceptStopWord.error.notfound", errorMessage);
+		Assertions.assertNotNull(successMessage);
+		Assertions.assertNotNull(errorMessage);
+		Assertions.assertEquals("ConceptStopWord.error.notfound", errorMessage);
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.web.controller.encounter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;
@@ -49,18 +49,18 @@ public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTe
 		
 		Patient oldPatient = encounter.getPatient();
 		Patient newPatient = Context.getPatientService().getPatient(201);
-		Assert.assertNotEquals(oldPatient, newPatient);
+		Assertions.assertNotEquals(oldPatient, newPatient);
 		
 		List<Encounter> newEncounter = Context.getEncounterService().getEncountersByPatientId(newPatient.getPatientId());
-		Assert.assertEquals(0, newEncounter.size());
+		Assertions.assertEquals(0, newEncounter.size());
 		
 		BindException errors = new BindException(encounter, "encounterRole");
 		
 		controller.onSubmit(request, response, encounter, errors);
 		
-		Assert.assertEquals(true, encounter.isVoided());
+		Assertions.assertEquals(true, encounter.isVoided());
 		newEncounter = Context.getEncounterService().getEncountersByPatientId(newPatient.getPatientId());
-		Assert.assertEquals(1, newEncounter.size());
-		Assert.assertEquals(false, newEncounter.get(0).isVoided());
+		Assertions.assertEquals(1, newEncounter.size());
+		Assertions.assertEquals(false, newEncounter.get(0).isVoided());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterRoleFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterRoleFormControllerTest.java
@@ -13,12 +13,12 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.EncounterRole;
 import org.openmrs.api.context.Context;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindException;
@@ -42,7 +42,7 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		encounterRole.setDescription("person in charge");
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.save(session, encounterRole, errors);
-		Assert.assertNotNull(encounterRole.getId());
+		Assertions.assertNotNull(encounterRole.getId());
 		
 	}
 	
@@ -60,8 +60,8 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		encounterRole.setDescription("person in charge");
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.save(session, encounterRole, errors);
-		Assert.assertNull(encounterRole.getId());
-		Assert.assertEquals(1, errors.getErrorCount());
+		Assertions.assertNull(encounterRole.getId());
+		Assertions.assertEquals(1, errors.getErrorCount());
 	}
 	
 	/**
@@ -82,9 +82,9 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		encounterRole.setDescription(description);
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.save(session, encounterRole, errors);
-		Assert.assertNotNull(encounterRole.getId());
-		Assert.assertEquals(roleName, encounterRole.getName());
-		Assert.assertEquals(description, encounterRole.getDescription());
+		Assertions.assertNotNull(encounterRole.getId());
+		Assertions.assertEquals(roleName, encounterRole.getName());
+		Assertions.assertEquals(description, encounterRole.getDescription());
 	}
 	
 	/**
@@ -102,9 +102,9 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		encounterRole.setRetireReason("this role is no more existing");
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.retire(session, encounterRole, errors);
-		Assert.assertNotNull(encounterRole.getId());
-		Assert.assertTrue(encounterRole.isRetired());
-		Assert.assertEquals("EncounterRole.retiredSuccessfully", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		Assertions.assertNotNull(encounterRole.getId());
+		Assertions.assertTrue(encounterRole.isRetired());
+		Assertions.assertEquals("EncounterRole.retiredSuccessfully", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
 	}
 	
 	/**
@@ -121,8 +121,8 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		EncounterRole encounterRole = Context.getEncounterService().getEncounterRole(2);
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.unretire(session, encounterRole, errors);
-		Assert.assertFalse(encounterRole.isRetired());
-		Assert.assertEquals("EncounterRole.unretired", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		Assertions.assertFalse(encounterRole.isRetired());
+		Assertions.assertEquals("EncounterRole.unretired", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
 	}
 	
 	/**
@@ -139,7 +139,7 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		EncounterRole encounterRole = Context.getEncounterService().getEncounterRole(1);
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.purge(session, encounterRole, errors);
-		Assert.assertEquals("EncounterRole.purgedSuccessfully", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		Assertions.assertEquals("EncounterRole.purgedSuccessfully", session.getAttribute(WebConstants.OPENMRS_MSG_ATTR));
 	}
 	
 	/**
@@ -152,8 +152,8 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		executeDataSet(ENC_INITIAL_DATA_XML);
 		EncounterRoleFormController controller = new EncounterRoleFormController();
 		String viewName = controller.getEncounterList(modelMap);
-		Assert.assertEquals("/module/legacyui/admin/encounters/encounterRoleList", viewName);
-		Assert.assertEquals(3, ((List) modelMap.get("encounterRoles")).size());
+		Assertions.assertEquals("/module/legacyui/admin/encounters/encounterRoleList", viewName);
+		Assertions.assertEquals(3, ((List) modelMap.get("encounterRoles")).size());
 	}
 	
 	/**
@@ -171,7 +171,7 @@ public class EncounterRoleFormControllerTest extends BaseModuleWebContextSensiti
 		encounterRole.setRetireReason(""); //setting empty retire reason so that it will raise an error.
 		BindException errors = new BindException(encounterRole, "encounterRole");
 		controller.retire(session, encounterRole, errors);
-		Assert.assertEquals(1, errors.getErrorCount());
+		Assertions.assertEquals(1, errors.getErrorCount());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterTypeFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterTypeFormControllerTest.java
@@ -11,11 +11,11 @@ package org.openmrs.web.controller.encounter;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -51,9 +51,9 @@ public class EncounterTypeFormControllerTest extends BaseModuleWebContextSensiti
 		// send the parameters to the controller
 		ModelAndView mav = controller.handleRequest(request, response);
 		
-		Assert.assertEquals("The purge attempt should have failed!", "EncounterType.form", mav.getViewName());
-		Assert.assertSame(controller.getFormView(), mav.getViewName());
-		Assert.assertNotNull(es.getEncounterType(1));
+		Assertions.assertEquals("EncounterType.form", mav.getViewName(), "The purge attempt should have failed!");
+		Assertions.assertSame(controller.getFormView(), mav.getViewName());
+		Assertions.assertNotNull(es.getEncounterType(1));
 	}
 	
 	@Test
@@ -78,8 +78,8 @@ public class EncounterTypeFormControllerTest extends BaseModuleWebContextSensiti
 		
 		ModelAndView mav = controller.handleRequest(request, response);
 		
-		Assert.assertSame(controller.getFormView(), mav.getViewName());
-		Assert.assertNotEquals("The save attempt should have passed!", "index.htm", mav.getViewName());
-		Assert.assertNotNull(es.getEncounterType(1));
+		Assertions.assertSame(controller.getFormView(), mav.getViewName());
+		Assertions.assertNotEquals("index.htm", mav.getViewName(), "The save attempt should have passed!");
+		Assertions.assertNotNull(es.getEncounterType(1));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterTypeListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterTypeListControllerTest.java
@@ -12,9 +12,9 @@ package org.openmrs.web.controller.encounter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/LocationFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/LocationFormControllerTest.java
@@ -12,12 +12,12 @@ package org.openmrs.web.controller.encounter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Location;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BeanPropertyBindingResult;
@@ -60,7 +60,7 @@ public class LocationFormControllerTest extends BaseModuleWebContextSensitiveTes
 		// make sure an error is returned because of the empty retire reason
 		BeanPropertyBindingResult bindingResult = (BeanPropertyBindingResult) modelAndView.getModel().get(
 		    "org.springframework.validation.BindingResult.location");
-		Assert.assertTrue(bindingResult.hasFieldErrors("retireReason"));
+		Assertions.assertTrue(bindingResult.hasFieldErrors("retireReason"));
 	}
 	
 	/**
@@ -79,7 +79,7 @@ public class LocationFormControllerTest extends BaseModuleWebContextSensitiveTes
 		((SimpleFormController) getLocationFormController()).handleRequest(request, response);
 		
 		Location retiredLocation = Context.getLocationService().getLocation(1);
-		Assert.assertTrue(retiredLocation.isRetired());
+		Assertions.assertTrue(retiredLocation.isRetired());
 	}
 	
 	/**
@@ -99,6 +99,6 @@ public class LocationFormControllerTest extends BaseModuleWebContextSensitiveTes
 		
 		// make sure there is an "locationId" filled in on the concept
 		Location command = (Location) modelAndView.getModel().get("location");
-		Assert.assertNotNull(command.getLocationId());
+		Assertions.assertNotNull(command.getLocationId());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/form/FieldFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/form/FieldFormControllerTest.java
@@ -12,12 +12,12 @@ package org.openmrs.web.controller.form;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Field;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,7 +48,7 @@ public class FieldFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		
 		// make sure there is a "userId" filled in on the concept
 		Field command = (Field) modelAndView.getModel().get("field");
-		Assert.assertNotNull(command.getFieldId());
+		Assertions.assertNotNull(command.getFieldId());
 	}
 	
 	/**
@@ -103,6 +103,6 @@ public class FieldFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		
 		controller.handleRequest(request, response);
 		
-		Assert.assertNull(Context.getFormService().getField(Integer.valueOf(FIELD_ID)));
+		Assertions.assertNull(Context.getFormService().getField(Integer.valueOf(FIELD_ID)));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/form/FieldTypeListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/form/FieldTypeListControllerTest.java
@@ -12,10 +12,10 @@ package org.openmrs.web.controller.form;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.openmrs.web.test.WebTestHelper;
 import org.openmrs.web.test.WebTestHelper.Response;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +43,6 @@ public class FieldTypeListControllerTest extends BaseModuleWebContextSensitiveTe
 		post.addParameter("fieldTypeId", "1");
 		
 		Response response = webTestHelper.handle(post);
-		Assert.assertNotNull(response.session.getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
+		Assertions.assertNotNull(response.session.getAttribute(WebConstants.OPENMRS_ERROR_ATTR));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/form/FormFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/form/FormFormControllerTest.java
@@ -11,12 +11,12 @@ package org.openmrs.web.controller.form;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -31,7 +31,7 @@ public class FormFormControllerTest extends BaseModuleWebContextSensitiveTest {
 	
 	private FormFormController controller;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		if (formService == null) {
 			formService = Context.getFormService();
@@ -59,10 +59,10 @@ public class FormFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		request.setContentType("application/x-www-form-urlencoded");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The save attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("formEdit.form", mav.getViewName());
-		Assert.assertSame(controller.getFormView(), mav.getViewName());
-		Assert.assertNotNull(formService.getForm(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The save attempt should have failed!");
+		Assertions.assertNotEquals("formEdit.form", mav.getViewName());
+		Assertions.assertSame(controller.getFormView(), mav.getViewName());
+		Assertions.assertNotNull(formService.getForm(1));
 	}
 	
 	@Test
@@ -79,9 +79,9 @@ public class FormFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		request.setContentType("application/x-www-form-urlencoded");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The duplicate attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("formEdit.form", mav.getViewName());
-		Assert.assertSame(controller.getFormView(), mav.getViewName());
-		Assert.assertNotNull(formService.getForm(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The duplicate attempt should have failed!");
+		Assertions.assertNotEquals("formEdit.form", mav.getViewName());
+		Assertions.assertSame(controller.getFormView(), mav.getViewName());
+		Assertions.assertNotNull(formService.getForm(1));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/maintenance/GlobalPropertyControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/maintenance/GlobalPropertyControllerTest.java
@@ -14,13 +14,13 @@ import java.util.Locale;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.MessageSource;
@@ -37,7 +37,7 @@ public class GlobalPropertyControllerTest extends BaseModuleWebContextSensitiveT
 	
 	private AdministrationService administrationService;
 	
-	@Before
+	@BeforeEach
 	public void before() {
 		messageSource = Context.getMessageSourceService();
 		administrationService = Context.getAdministrationService();
@@ -65,14 +65,14 @@ public class GlobalPropertyControllerTest extends BaseModuleWebContextSensitiveT
 		
 		controller.handleRequest(request, response);
 		
-		Assert.assertEquals(2, administrationService.getAllGlobalProperties().size());
+		Assertions.assertEquals(2, administrationService.getAllGlobalProperties().size());
 		for (GlobalProperty globalProperty : administrationService.getAllGlobalProperties()) {
 			if (globalProperty.getProperty().equals("test2")) {
-				Assert.assertEquals("test2_value", globalProperty.getPropertyValue());
+				Assertions.assertEquals("test2_value", globalProperty.getPropertyValue());
 			} else if (globalProperty.getProperty().equals("test3")) {
-				Assert.assertEquals("test3_value", globalProperty.getPropertyValue());
+				Assertions.assertEquals("test3_value", globalProperty.getPropertyValue());
 			} else {
-				Assert.fail("Should be either test2 or test3");
+				Assertions.fail("Should be either test2 or test3");
 			}
 		}
 	}
@@ -99,14 +99,14 @@ public class GlobalPropertyControllerTest extends BaseModuleWebContextSensitiveT
 		
 		controller.handleRequest(request, response);
 		
-		Assert.assertEquals(2, administrationService.getAllGlobalProperties().size());
+		Assertions.assertEquals(2, administrationService.getAllGlobalProperties().size());
 		for (GlobalProperty globalProperty : administrationService.getAllGlobalProperties()) {
 			if (globalProperty.getProperty().equals("test1")) {
-				Assert.assertEquals(globalProperty.getPropertyValue(), "test1_new_value");
+				Assertions.assertEquals(globalProperty.getPropertyValue(), "test1_new_value");
 			} else if (globalProperty.getProperty().equals("test2")) {
-				Assert.assertEquals("test2_value", globalProperty.getPropertyValue());
+				Assertions.assertEquals("test2_value", globalProperty.getPropertyValue());
 			} else {
-				Assert.fail("Should be either test1 or test2");
+				Assertions.fail("Should be either test1 or test2");
 			}
 		}
 	}

--- a/omod/src/test/java/org/openmrs/web/controller/maintenance/SearchIndexControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/maintenance/SearchIndexControllerTest.java
@@ -9,10 +9,8 @@
  */
 package org.openmrs.web.controller.maintenance;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
@@ -20,15 +18,15 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
 import org.openmrs.api.db.ContextDAO;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.doThrow;
@@ -46,13 +44,11 @@ public class SearchIndexControllerTest extends BaseModuleWebContextSensitiveTest
 	@Mock
 	private UserContext userContext;
 	
-	@Before
+	@BeforeEach
 	public void before() {
 		controller = new SearchIndexController();
 	}
 	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
 	
 	/**
 	 * @verifies return the search index view
@@ -105,7 +101,6 @@ public class SearchIndexControllerTest extends BaseModuleWebContextSensitiveTest
 		when(userContext.isAuthenticated()).thenReturn(false);
 		assertFalse(Context.getUserContext().isAuthenticated());
 		
-		when(contextDao.updateSearchIndexAsync()).thenReturn(null);
 		Map<String, Object> response = controller.rebuildSearchIndex();
 		assertEquals(false, response.get("success"));
 	}
@@ -166,8 +161,8 @@ public class SearchIndexControllerTest extends BaseModuleWebContextSensitiveTest
 	 */
 	@Test
 	public void getStatus_shouldThrowApiExceptionWhenRebuildSearchIndexNotHaveBeenCalledBefore() throws Exception {
-		expectedException.expect(APIException.class);
-		expectedException.expectMessage("There was a problem rebuilding the search index");
-		controller.getStatus();
+		APIException ex = org.junit.jupiter.api.Assertions.assertThrows(APIException.class,
+			() -> controller.getStatus());
+		assertTrue(ex.getMessage().contains("There was a problem rebuilding the search index"));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/maintenance/SystemInformationControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/maintenance/SystemInformationControllerTest.java
@@ -11,12 +11,12 @@ package org.openmrs.web.controller.maintenance;
 
 import java.util.Map;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.ui.ModelMap;
 
 /**
@@ -26,7 +26,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	
 	private ModelMap model = null;
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		createController();
 	}
@@ -47,7 +47,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	@Test
 	@Verifies(value = "should add openmrs information attribute to the model map", method = "showPage()")
 	public void showPage_shouldReturnOpenmrsInformation() {
-		Assert.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
+		Assertions.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
 		        .containsKey("SystemInfo.title.openmrsInformation"));
 	}
 	
@@ -57,7 +57,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	@Test
 	@Verifies(value = "should add java runtime information attribute to the model map", method = "showPage()")
 	public void showPage_shouldReturnUserInformation() {
-		Assert.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
+		Assertions.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
 		        .containsKey("SystemInfo.title.javaRuntimeEnvironmentInformation"));
 	}
 	
@@ -67,7 +67,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	@Test
 	@Verifies(value = "should add module information attribute to the model map", method = "showPage()")
 	public void showPage_shouldReturnAllJavaRuntimeInformation() {
-		Assert.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
+		Assertions.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
 		        .containsKey("SystemInfo.title.moduleInformation"));
 	}
 	
@@ -77,7 +77,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	@Test
 	@Verifies(value = "should add database information attribute to the model map", method = "showPage()")
 	public void showPage_shouldReturnAllDatabaseInformation() {
-		Assert.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
+		Assertions.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
 		        .containsKey("SystemInfo.title.dataBaseInformation"));
 	}
 	
@@ -87,7 +87,7 @@ public class SystemInformationControllerTest extends BaseModuleWebContextSensiti
 	@Test
 	@Verifies(value = "should add memory information attribute to the model map", method = "getMemoryInformation()")
 	public void getMemoryInformation_shouldReturnMemoryInformation() {
-		Assert.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
+		Assertions.assertTrue(((Map<String, Map<String, String>>) model.get("systemInfo"))
 		        .containsKey("SystemInfo.title.memoryInformation"));
 	}
 	

--- a/omod/src/test/java/org/openmrs/web/controller/observation/ObsFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/observation/ObsFormControllerTest.java
@@ -9,19 +9,19 @@
  */
 package org.openmrs.web.controller.observation;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -50,7 +50,7 @@ public class ObsFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		
 		// make sure there is an "encounterId" element on the obs
 		Obs commandObs = (Obs) modelAndView.getModel().get("command");
-		Assert.assertNotNull(commandObs.getEncounter());
+		Assertions.assertNotNull(commandObs.getEncounter());
 		
 	}
 	

--- a/omod/src/test/java/org/openmrs/web/controller/patient/PatientDashboardControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/patient/PatientDashboardControllerTest.java
@@ -11,18 +11,18 @@ package org.openmrs.web.controller.patient;
 
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Method;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.ui.ModelMap;
@@ -49,7 +49,7 @@ public class PatientDashboardControllerTest extends BaseModuleWebContextSensitiv
 	
 	private Method getPatientMethod;
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws NoSuchMethodException, SecurityException {
 		getPatientMethod = PatientDashboardController.class.getDeclaredMethod("getPatient", new Class[] { String.class });
 		getPatientMethod.setAccessible(true);

--- a/omod/src/test/java/org/openmrs/web/controller/patient/PatientFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/patient/PatientFormControllerTest.java
@@ -9,15 +9,15 @@
  */
 package org.openmrs.web.controller.patient;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
-import org.openmrs.web.test.BaseWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;
@@ -54,7 +54,7 @@ public class PatientFormControllerTest extends BaseModuleWebContextSensitiveTest
 		BindException errors = new BindException(p, "patient");
 		ModelAndView modelAndview = controller.onSubmit(request, response, p, errors);
 		
-		Assert.assertTrue(p.isVoided());
+		Assertions.assertTrue(p.isVoided());
 	}
 	
 	/**
@@ -78,8 +78,8 @@ public class PatientFormControllerTest extends BaseModuleWebContextSensitiveTest
 		BindException errors = new BindException(p, "patient");
 		ModelAndView modelAndview = controller.onSubmit(request, response, p, errors);
 		
-		Assert.assertTrue(!p.isVoided());
+		Assertions.assertTrue(!p.isVoided());
 		String tmp = request.getSession().getAttribute(WebConstants.OPENMRS_ERROR_ATTR).toString();
-		Assert.assertEquals(tmp, "Patient.error.void.reasonEmpty");
+		Assertions.assertEquals(tmp, "Patient.error.void.reasonEmpty");
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/patient/PatientIdentifierTypeFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/patient/PatientIdentifierTypeFormControllerTest.java
@@ -11,11 +11,11 @@ package org.openmrs.web.controller.patient;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -32,7 +32,7 @@ public class PatientIdentifierTypeFormControllerTest extends BaseModuleWebContex
 	
 	private PatientIdentifierTypeFormController controller;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		executeDataSet("org/openmrs/web/patient/include/PatientIdentifierTypeFormControllerTest.xml");
 		controller = (PatientIdentifierTypeFormController) applicationContext.getBean("patientIdentifierTypeForm");
@@ -51,9 +51,9 @@ public class PatientIdentifierTypeFormControllerTest extends BaseModuleWebContex
 		request.addParameter("save", "Save Identifier Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The save attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("patientIdentifierType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The save attempt should have failed!");
+		Assertions.assertNotEquals("patientIdentifierType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -62,9 +62,9 @@ public class PatientIdentifierTypeFormControllerTest extends BaseModuleWebContex
 		request.addParameter("retireReason", "Same reason");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The retire attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("patientIdentifierType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The retire attempt should have failed!");
+		Assertions.assertNotEquals("patientIdentifierType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -72,9 +72,9 @@ public class PatientIdentifierTypeFormControllerTest extends BaseModuleWebContex
 		request.addParameter("unretire", "Unretire Identifier Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The unretire attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("patientIdentifierType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The unretire attempt should have failed!");
+		Assertions.assertNotEquals("patientIdentifierType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -82,8 +82,8 @@ public class PatientIdentifierTypeFormControllerTest extends BaseModuleWebContex
 		request.addParameter("purge", "Delete Identifier Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The delete attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("patientIdentifierType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The delete attempt should have failed!");
+		Assertions.assertNotEquals("patientIdentifierType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/patient/ShortPatientFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/patient/ShortPatientFormControllerTest.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.web.controller.patient;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -19,8 +19,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.beanutils.BeanUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.GlobalProperty;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
@@ -35,8 +35,8 @@ import org.openmrs.util.LocationUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
-import org.openmrs.web.test.BaseWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest;
 import org.openmrs.web.test.WebTestHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -78,10 +78,10 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		    (PersonAddress) mockWebRequest.getAttribute("personAddressCache", WebRequest.SCOPE_SESSION), null,
 		    (ShortPatientModel) mockWebRequest.getAttribute("patientModel", WebRequest.SCOPE_SESSION), errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 	}
 	
 	/**
@@ -112,15 +112,15 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String redirectUrl = controller.saveShortPatient(mockWebRequest, new PersonName(), new PersonAddress(), null,
 		    patientModel, errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertNotNull(p.getId());
-		Assert.assertNotNull(p.getPersonName());
-		Assert.assertNotNull(p.getPersonName().getId());// the name was create
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertNotNull(p.getId());
+		Assertions.assertNotNull(p.getPersonName());
+		Assertions.assertNotNull(p.getPersonName().getId());// the name was create
 		// and added
-		Assert.assertEquals(patientCount + 1, Context.getPatientService().getAllPatients().size());
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertEquals(patientCount + 1, Context.getPatientService().getAllPatients().size());
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 	}
 	
 	/**
@@ -144,8 +144,8 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String formUrl = controller.saveShortPatient(mockWebRequest, new PersonName(), new PersonAddress(), null,
 		    patientModel, errors);
 		
-		Assert.assertTrue("Should report validation errors", errors.hasErrors());
-		Assert.assertEquals("module/legacyui/admin/patients/shortPatientForm", formUrl);
+		Assertions.assertTrue(errors.hasErrors(), "Should report validation errors");
+		Assertions.assertEquals("module/legacyui/admin/patients/shortPatientForm", formUrl);
 	}
 	
 	/**
@@ -172,15 +172,15 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String redirectUrl = controller.saveShortPatient(mockWebRequest, personNameCache, (PersonAddress) p
 		        .getPersonAddress().clone(), null, patientModel, errors);
 		
-		Assert.assertEquals(nameCount + 1, p.getNames().size());
-		Assert.assertTrue("The old name should be voided", oldPersonName.isVoided());
-		Assert.assertNotNull("The void reason should be set", oldPersonName.getVoidReason());
-		Assert.assertTrue("The old name should have remained un changed",
-		    oldGivenName.equalsIgnoreCase(oldPersonName.getGivenName()));
-		Assert.assertEquals("Changed", p.getGivenName());// the changes should
+		Assertions.assertEquals(nameCount + 1, p.getNames().size());
+		Assertions.assertTrue(oldPersonName.isVoided(), "The old name should be voided");
+		Assertions.assertNotNull(oldPersonName.getVoidReason(), "The void reason should be set");
+		Assertions.assertTrue(oldGivenName.equalsIgnoreCase(oldPersonName.getGivenName()),
+		    "The old name should have remained un changed");
+		Assertions.assertEquals("Changed", p.getGivenName());// the changes should
 		// have taken effect
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 	}
 	
 	/**
@@ -195,7 +195,7 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		//to have at least one non voided name.
 		/*p.getPersonName().setVoided(true);
 		Context.getPatientService().savePatient(p);
-		Assert.assertNull(p.getPersonName());// make sure all names are voided*/
+		Assertions.assertNull(p.getPersonName());// make sure all names are voided*/
 		
 		// add a name that will used as a duplicate for testing purposes
 		PersonName newName = new PersonName("new", null, "name");
@@ -211,9 +211,9 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String redirectUrl = controller.saveShortPatient(mockWebRequest, new PersonName(), (PersonAddress) p
 		        .getPersonAddress().clone(), null, patientModel, errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
-		Assert.assertNotNull(newName.getId());// name should have been added to
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertNotNull(newName.getId());// name should have been added to
 		// DB
 	}
 	
@@ -240,18 +240,18 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		        .getBean("shortPatientFormController");
 		String redirectUrl = controller.saveShortPatient(mockWebRequest,
 		    (PersonName) BeanUtils.cloneBean(p.getPersonName()), personAddressCache, null, patientModel, errors);
-		Assert.assertEquals(addressCount + 1, p.getAddresses().size());
-		Assert.assertTrue("The old address should be voided", oldPersonAddress.isVoided());
-		Assert.assertNotNull("The void reason should be set", oldPersonAddress.getVoidReason());
-		Assert.assertTrue("The old address should have remained the same",
-		    oldAddress1.equalsIgnoreCase(oldPersonAddress.getAddress1()));
-		Assert.assertEquals("Kampala", p.getPersonAddress().getAddress1());// the
+		Assertions.assertEquals(addressCount + 1, p.getAddresses().size());
+		Assertions.assertTrue(oldPersonAddress.isVoided(), "The old address should be voided");
+		Assertions.assertNotNull(oldPersonAddress.getVoidReason(), "The void reason should be set");
+		Assertions.assertTrue(oldAddress1.equalsIgnoreCase(oldPersonAddress.getAddress1()),
+		    "The old address should have remained the same");
+		Assertions.assertEquals("Kampala", p.getPersonAddress().getAddress1());// the
 		// changes
 		// should
 		// have
 		// taken
 		// effect
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 	}
 	
 	/**
@@ -264,7 +264,7 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		Patient p = Context.getPatientService().getPatient(2);
 		p.getPersonAddress().setVoided(true);
 		Context.getPatientService().savePatient(p);
-		Assert.assertNull(p.getPersonAddress());// make sure all addresses are
+		Assertions.assertNull(p.getPersonAddress());// make sure all addresses are
 		// voided
 		
 		// add a name that will used as a duplicate for testing purposes
@@ -282,9 +282,9 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String redirectUrl = controller.saveShortPatient(mockWebRequest,
 		    (PersonName) BeanUtils.cloneBean(p.getPersonName()), new PersonAddress(), null, patientModel, errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
-		Assert.assertNotNull(newAddress.getId());// name should have been added
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertNotNull(newAddress.getId());// name should have been added
 		// to DB
 	}
 	
@@ -299,7 +299,7 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		Context.getPatientService().savePatient(p);
 		// make sure all addresses are voided so that whatever is entered a new
 		// address
-		Assert.assertNull(p.getPersonAddress());
+		Assertions.assertNull(p.getPersonAddress());
 		
 		// add the new address
 		PersonAddress newAddress = new PersonAddress();
@@ -317,10 +317,10 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		String redirectUrl = controller.saveShortPatient(mockWebRequest,
 		    (PersonName) BeanUtils.cloneBean(p.getPersonName()), new PersonAddress(), null, patientModel, errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 		// address should have been ignored
-		Assert.assertNull(p.getPersonAddress());
+		Assertions.assertNull(p.getPersonAddress());
 	}
 	
 	/**
@@ -353,15 +353,15 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		    (PersonName) mockWebRequest.getAttribute("personNameCache", WebRequest.SCOPE_SESSION),
 		    (PersonAddress) mockWebRequest.getAttribute("personAddressCache", WebRequest.SCOPE_SESSION), null,
 		    (ShortPatientModel) mockWebRequest.getAttribute("patientModel", WebRequest.SCOPE_SESSION), errors);
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
 		
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 		//The new person attribute should have been added and saved
-		Assert.assertNotNull(p.getAttribute(2).getPersonAttributeId());
-		Assert.assertEquals(birthPlace, p.getAttribute(2).getValue());
-		Assert.assertEquals(originalAttributeCount + 1, p.getAttributes().size());
+		Assertions.assertNotNull(p.getAttribute(2).getPersonAttributeId());
+		Assertions.assertEquals(birthPlace, p.getAttribute(2).getValue());
+		Assertions.assertEquals(originalAttributeCount + 1, p.getAttributes().size());
 	}
 	
 	/**
@@ -391,12 +391,12 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		    (PersonAddress) mockWebRequest.getAttribute("personAddressCache", WebRequest.SCOPE_SESSION), null,
 		    (ShortPatientModel) mockWebRequest.getAttribute("patientModel", WebRequest.SCOPE_SESSION), errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
-		Assert.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
+		Assertions.assertEquals("redirect:/patientDashboard.form?patientId=" + p.getPatientId(), redirectUrl);
 		//The new blank person attribute should have been ignored
-		Assert.assertEquals(originalAttributeCount, p.getAttributes().size());
+		Assertions.assertEquals(originalAttributeCount, p.getAttributes().size());
 	}
 	
 	/**
@@ -434,8 +434,8 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 			}
 		}
 		//ensure we found and edited it
-		Assert.assertNotNull(attributeToEdit);
-		Assert.assertNotNull(oldValue);
+		Assertions.assertNotNull(attributeToEdit);
+		Assertions.assertNotNull(oldValue);
 		
 		WebRequest mockWebRequest = new ServletWebRequest(new MockHttpServletRequest());
 		BindException errors = new BindException(patientModel, "patientModel");
@@ -450,12 +450,12 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		    (PersonAddress) mockWebRequest.getAttribute("personAddressCache", WebRequest.SCOPE_SESSION), null,
 		    (ShortPatientModel) mockWebRequest.getAttribute("patientModel", WebRequest.SCOPE_SESSION), errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
 		
 		//the attribute should have been voided
-		Assert.assertEquals(originalActiveAttributeCount - 1, p.getActiveAttributes().size());
+		Assertions.assertEquals(originalActiveAttributeCount - 1, p.getActiveAttributes().size());
 	}
 	
 	/**
@@ -493,8 +493,8 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 			}
 		}
 		//ensure we found and edited it
-		Assert.assertNotNull(attributeToEdit);
-		Assert.assertNotNull(oldValue);
+		Assertions.assertNotNull(attributeToEdit);
+		Assertions.assertNotNull(oldValue);
 		
 		WebRequest mockWebRequest = new ServletWebRequest(new MockHttpServletRequest());
 		BindException errors = new BindException(patientModel, "patientModel");
@@ -509,14 +509,14 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		    (PersonAddress) mockWebRequest.getAttribute("personAddressCache", WebRequest.SCOPE_SESSION), null,
 		    (ShortPatientModel) mockWebRequest.getAttribute("patientModel", WebRequest.SCOPE_SESSION), errors);
 		
-		Assert.assertTrue("Should pass with no validation errors", !errors.hasErrors());
-		Assert.assertEquals("Patient.saved",
+		Assertions.assertTrue(!errors.hasErrors(), "Should pass with no validation errors");
+		Assertions.assertEquals("Patient.saved",
 		    mockWebRequest.getAttribute(WebConstants.OPENMRS_MSG_ATTR, WebRequest.SCOPE_SESSION));
 		
 		//a new replacement attribute should have been created with the new value
 		PersonAttribute newAttribute = p.getAttribute(attributeTypeId);
-		Assert.assertEquals(originalAttributeCount + 1, p.getAttributes().size());
-		Assert.assertEquals(newValue, newAttribute.getValue());
+		Assertions.assertEquals(originalAttributeCount + 1, p.getAttributes().size());
+		Assertions.assertEquals(newValue, newAttribute.getValue());
 		
 		PersonAttribute oldAttribute = null;
 		//find the voided attribute
@@ -531,9 +531,9 @@ public class ShortPatientFormControllerTest extends BaseModuleWebContextSensitiv
 		}
 		
 		//The old attribute should have been voided and maintained its old value
-		Assert.assertNotNull(oldAttribute);
-		Assert.assertEquals(oldValue, oldAttribute.getValue());
-		Assert.assertTrue(oldAttribute.isVoided());
+		Assertions.assertNotNull(oldAttribute);
+		Assertions.assertEquals(oldValue, oldAttribute.getValue());
+		Assertions.assertTrue(oldAttribute.isVoided());
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/web/controller/patient/ShortPatientFormValidatorTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/patient/ShortPatientFormValidatorTest.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.web.controller.patient;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.Location;
 import org.openmrs.Patient;
@@ -22,7 +22,7 @@ import org.openmrs.PersonName;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ObjectError;
@@ -42,7 +42,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 	 * 
 	 * @throws Exception
 	 */
-	@Before
+	@BeforeEach
 	public void runBeforeAllTests() throws Exception {
 		validator = new ShortPatientFormValidator();
 		ps = Context.getPatientService();
@@ -60,7 +60,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasGlobalErrors());
+		Assertions.assertEquals(true, errors.hasGlobalErrors());
 	}
 	
 	/**
@@ -75,7 +75,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasGlobalErrors());
+		Assertions.assertEquals(true, errors.hasGlobalErrors());
 	}
 	
 	/**
@@ -90,7 +90,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+		Assertions.assertEquals(true, errors.hasErrors());
 	}
 	
 	/**
@@ -110,7 +110,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasGlobalErrors());
+		Assertions.assertEquals(true, errors.hasGlobalErrors());
 	}
 	
 	/**
@@ -128,7 +128,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -145,7 +145,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -159,7 +159,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -175,7 +175,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -194,7 +194,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -208,7 +208,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -228,7 +228,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		model.setPersonAddress(new PersonAddress());
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(false, errors.hasErrors());
+		Assertions.assertEquals(false, errors.hasErrors());
 		
 	}
 	
@@ -245,7 +245,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		ShortPatientModel model = new ShortPatientModel(p);
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasFieldErrors());
+		Assertions.assertEquals(true, errors.hasFieldErrors());
 	}
 	
 	/**
@@ -256,16 +256,16 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 	public void validate_shouldRejectADuplicateName() throws Exception {
 		Patient patient = ps.getPatient(7);
 		PersonName oldName = patient.getPersonName();
-		Assert.assertEquals(1, patient.getNames().size());//sanity check
+		Assertions.assertEquals(1, patient.getNames().size());//sanity check
 		//add a name for testing purposes
 		PersonName name = new PersonName("my", "duplicate", "name");
 		patient.addName(name);
 		Context.getPatientService().savePatient(patient);
-		Assert.assertNotNull(name.getId());//should have been added
+		Assertions.assertNotNull(name.getId());//should have been added
 		
 		ShortPatientModel model = new ShortPatientModel(patient);
 		//should still be the preferred name for the test to pass
-		Assert.assertEquals(oldName.getId(), model.getPersonName().getId());
+		Assertions.assertEquals(oldName.getId(), model.getPersonName().getId());
 		//change to a duplicate name
 		model.getPersonName().setGivenName("My");//should be case insensitive
 		model.getPersonName().setMiddleName("duplicate");
@@ -273,7 +273,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+		Assertions.assertEquals(true, errors.hasErrors());
 	}
 	
 	/**
@@ -284,7 +284,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 	public void validate_shouldRejectADuplicateAddress() throws Exception {
 		Patient patient = ps.getPatient(2);
 		PersonAddress oldAddress = patient.getPersonAddress();
-		Assert.assertEquals(1, patient.getAddresses().size());//sanity check
+		Assertions.assertEquals(1, patient.getAddresses().size());//sanity check
 		//add a name for testing purposes
 		PersonAddress address = (PersonAddress) oldAddress.clone();
 		address.setPersonAddressId(null);
@@ -293,18 +293,18 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		address.setAddress2("address2");
 		patient.addAddress(address);
 		Context.getPatientService().savePatient(patient);
-		Assert.assertNotNull(address.getId());//should have been added
+		Assertions.assertNotNull(address.getId());//should have been added
 		
 		ShortPatientModel model = new ShortPatientModel(patient);
 		//should still be the preferred address for the test to pass
-		Assert.assertEquals(oldAddress.getId(), model.getPersonAddress().getId());
+		Assertions.assertEquals(oldAddress.getId(), model.getPersonAddress().getId());
 		//change to a duplicate name
 		model.getPersonAddress().setAddress1("Address1");//should be case insensitive
 		model.getPersonAddress().setAddress2("address2");
 		
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+		Assertions.assertEquals(true, errors.hasErrors());
 	}
 	
 	/**
@@ -320,7 +320,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		name.setVoided(true);
 		patient.addName(name);
 		Context.getPatientService().savePatient(patient);
-		Assert.assertNotNull(name.getId());//should have been added
+		Assertions.assertNotNull(name.getId());//should have been added
 		
 		ShortPatientModel model = new ShortPatientModel(patient);
 		
@@ -332,9 +332,9 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		//Check validator has errors
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(true, errors.hasErrors());
+		Assertions.assertEquals(true, errors.hasErrors());
 		ObjectError error = errors.getAllErrors().get(0);
-		Assert.assertTrue(error.getDefaultMessage().contains("Please restore the existing name"));
+		Assertions.assertTrue(error.getDefaultMessage().contains("Please restore the existing name"));
 	}
 	
 	@Test
@@ -342,7 +342,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 	public void validate_shouldIgnoreDuplicateVoidedAddress() throws Exception {
 		Patient patient = ps.getPatient(2);
 		PersonAddress oldAddress = patient.getPersonAddress();
-		Assert.assertEquals(1, patient.getAddresses().size());//sanity check
+		Assertions.assertEquals(1, patient.getAddresses().size());//sanity check
 		oldAddress.setAddress1("Address1");
 		oldAddress.setAddress2("address1");
 		Context.getPatientService().savePatient(patient);
@@ -354,7 +354,7 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		address.setAddress2("address2");
 		patient.addAddress(address);
 		Context.getPatientService().savePatient(patient);
-		Assert.assertNotNull(address.getId());//should have been added
+		Assertions.assertNotNull(address.getId());//should have been added
 		//void the first address
 		oldAddress.setVoided(true);
 		oldAddress.setVoidReason("test duplicate address");
@@ -362,13 +362,13 @@ public class ShortPatientFormValidatorTest extends BaseModuleWebContextSensitive
 		
 		ShortPatientModel model = new ShortPatientModel(patient);
 		//the second address should be now the active address
-		Assert.assertEquals(address.getId(), model.getPersonAddress().getId());
+		Assertions.assertEquals(address.getId(), model.getPersonAddress().getId());
 		//change to a duplicate name
 		model.getPersonAddress().setAddress1("address1");//should be case insensitive
 		model.getPersonAddress().setAddress2("address1");
 		
 		Errors errors = new BindException(model, "patientModel");
 		validator.validate(model, errors);
-		Assert.assertEquals(false, errors.hasErrors());
+		Assertions.assertEquals(false, errors.hasErrors());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/person/AddPersonControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/person/AddPersonControllerTest.java
@@ -9,15 +9,15 @@
  */
 package org.openmrs.web.controller.person;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Test;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.junit.jupiter.api.Test;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;

--- a/omod/src/test/java/org/openmrs/web/controller/person/PersonAttributeTypeFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/person/PersonAttributeTypeFormControllerTest.java
@@ -11,11 +11,11 @@ package org.openmrs.web.controller.person;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -32,7 +32,7 @@ public class PersonAttributeTypeFormControllerTest extends BaseModuleWebContextS
 	
 	private PersonAttributeTypeFormController controller;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		executeDataSet("org/openmrs/web/controller/include/PersonAttributeTypeFormControllerTest.xml");
 		controller = (PersonAttributeTypeFormController) applicationContext.getBean("personAttributeTypeForm");
@@ -52,9 +52,9 @@ public class PersonAttributeTypeFormControllerTest extends BaseModuleWebContextS
 		request.addParameter("save", "Save Person Attribute Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The save attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("PersonAttributeType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The save attempt should have failed!");
+		Assertions.assertNotEquals("PersonAttributeType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -62,9 +62,9 @@ public class PersonAttributeTypeFormControllerTest extends BaseModuleWebContextS
 		request.addParameter("purge", "Delete Person Attribute Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The delete attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("PersonAttributeType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The delete attempt should have failed!");
+		Assertions.assertNotEquals("PersonAttributeType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -73,9 +73,9 @@ public class PersonAttributeTypeFormControllerTest extends BaseModuleWebContextS
 		request.addParameter("retireReason", "Same reason");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The retire attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("PersonAttributeType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The retire attempt should have failed!");
+		Assertions.assertNotEquals("PersonAttributeType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 	
 	@Test
@@ -83,8 +83,8 @@ public class PersonAttributeTypeFormControllerTest extends BaseModuleWebContextS
 		request.addParameter("unretire", "Unretire Person Attribute Type");
 		
 		ModelAndView mav = controller.handleRequest(request, response);
-		Assert.assertEquals("The unretire attempt should have failed!", "index.htm", mav.getViewName());
-		Assert.assertNotEquals("PersonAttributeType.form", mav.getViewName());
-		Assert.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
+		Assertions.assertEquals("index.htm", mav.getViewName(), "The unretire attempt should have failed!");
+		Assertions.assertNotEquals("PersonAttributeType.form", mav.getViewName());
+		Assertions.assertNotNull(Context.getPersonService().getPersonAttributeType(1));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/person/PersonAttributeTypeListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/person/PersonAttributeTypeListControllerTest.java
@@ -13,13 +13,13 @@ import java.util.List;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
 import org.openmrs.util.OpenmrsConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.ui.ModelMap;
 
@@ -48,7 +48,7 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 		ModelMap map = new ModelMap();
 		new PersonAttributeTypeListController().displayPage(map);
 		List<PersonAttributeType> alltypes = (List<PersonAttributeType>) map.get("personAttributeTypeList");
-		Assert.assertEquals(3, alltypes.size());
+		Assertions.assertEquals(3, alltypes.size());
 	}
 	
 	/**
@@ -59,13 +59,13 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 	public void moveDown_shouldMoveSelectedIdsDownInTheList() throws Exception {
 		// sanity check
 		List<PersonAttributeType> allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals(1, allTypes.get(0).getId().intValue());
+		Assertions.assertEquals(1, allTypes.get(0).getId().intValue());
 		
 		// the test
 		Integer[] ids = new Integer[] { 1 };
 		new PersonAttributeTypeListController().moveDown(ids, new MockHttpSession());
 		allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals("The types didn't move correctly", 8, allTypes.get(0).getId().intValue());
+		Assertions.assertEquals(8, allTypes.get(0).getId().intValue(), "The types didn't move correctly");
 	}
 	
 	/**
@@ -76,13 +76,13 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 	public void moveDown_shouldNotFailIfGivenLastId() throws Exception {
 		// sanity check
 		List<PersonAttributeType> allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals(2, allTypes.get(allTypes.size() - 1).getId().intValue());
+		Assertions.assertEquals(2, allTypes.get(allTypes.size() - 1).getId().intValue());
 		
 		// the test
 		Integer[] ids = new Integer[] { 2 };
 		new PersonAttributeTypeListController().moveDown(ids, new MockHttpSession());
 		allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals(2, allTypes.get(allTypes.size() - 1).getId().intValue());
+		Assertions.assertEquals(2, allTypes.get(allTypes.size() - 1).getId().intValue());
 	}
 	
 	/**
@@ -104,13 +104,13 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 		
 		// sanity check
 		List<PersonAttributeType> allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals(8, allTypes.get(1).getId().intValue());
+		Assertions.assertEquals(8, allTypes.get(1).getId().intValue());
 		
 		// the test
 		Integer[] ids = new Integer[] { 8 };
 		new PersonAttributeTypeListController().moveUp(ids, new MockHttpSession());
 		allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals("The types didn't move correctly", 8, allTypes.get(0).getId().intValue());
+		Assertions.assertEquals(8, allTypes.get(0).getId().intValue(), "The types didn't move correctly");
 	}
 	
 	/**
@@ -121,7 +121,7 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 	public void moveUp_shouldNotFailIfGivenFirstId() throws Exception {
 		// sanity check
 		List<PersonAttributeType> allTypes = Context.getPersonService().getAllPersonAttributeTypes();
-		Assert.assertEquals(1, allTypes.get(0).getId().intValue());
+		Assertions.assertEquals(1, allTypes.get(0).getId().intValue());
 		
 		// the test
 		new PersonAttributeTypeListController().moveUp(new Integer[] { 1 }, new MockHttpSession());
@@ -146,6 +146,6 @@ public class PersonAttributeTypeListControllerTest extends BaseModuleWebContextS
 		new PersonAttributeTypeListController().updateGlobalProperties("asdf", "", "", "", "", new MockHttpSession());
 		String attr = Context.getAdministrationService().getGlobalProperty(
 		    OpenmrsConstants.GLOBAL_PROPERTY_PATIENT_LISTING_ATTRIBUTES);
-		Assert.assertEquals("asdf", attr);
+		Assertions.assertEquals("asdf", attr);
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/program/ProgramFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/program/ProgramFormControllerTest.java
@@ -12,11 +12,11 @@ package org.openmrs.web.controller.program;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +36,7 @@ public class ProgramFormControllerTest extends BaseModuleWebContextSensitiveTest
 	public void onSubmit_shouldSaveWorkflowsWithProgram() throws Exception {
 		
 		// sanity check to make sure that program #3 doesn't have any workflows already:
-		Assert.assertEquals(0, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
+		Assertions.assertEquals(0, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
 		
 		MockHttpServletRequest request = new MockHttpServletRequest("POST", "");
 		request.setParameter("programId", "3");
@@ -45,8 +45,8 @@ public class ProgramFormControllerTest extends BaseModuleWebContextSensitiveTest
 		ProgramFormController controller = (ProgramFormController) applicationContext.getBean("programForm");
 		controller.handleRequest(request, new MockHttpServletResponse());
 		
-		Assert.assertNotSame(0, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
-		Assert.assertEquals(1, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
+		Assertions.assertNotSame(0, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
+		Assertions.assertEquals(1, Context.getProgramWorkflowService().getProgram(3).getAllWorkflows().size());
 	}
 	
 	/**
@@ -65,7 +65,7 @@ public class ProgramFormControllerTest extends BaseModuleWebContextSensitiveTest
 
 		Context.clearSession();
 		
-		Assert.assertEquals(2, Context.getProgramWorkflowService().getProgram(3).getWorkflows().size());
+		Assertions.assertEquals(2, Context.getProgramWorkflowService().getProgram(3).getWorkflows().size());
 		
 		request = new MockHttpServletRequest("POST", "");
 		request.setParameter("programId", "3");
@@ -73,8 +73,8 @@ public class ProgramFormControllerTest extends BaseModuleWebContextSensitiveTest
 		
 		controller.handleRequest(request, new MockHttpServletResponse());
 		
-		Assert.assertEquals(1, Context.getProgramWorkflowService().getProgram(3).getWorkflows().size());
-		Assert.assertEquals(5, Context.getProgramWorkflowService().getProgram(3).getWorkflows().iterator().next()
+		Assertions.assertEquals(1, Context.getProgramWorkflowService().getProgram(3).getWorkflows().size());
+		Assertions.assertEquals(5, Context.getProgramWorkflowService().getProgram(3).getWorkflows().iterator().next()
 		        .getConcept().getConceptId().intValue());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/program/WorkflowFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/program/WorkflowFormControllerTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.web.controller.program;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.ProgramWorkflow;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.web.servlet.ModelAndView;
@@ -43,7 +43,7 @@ public class WorkflowFormControllerTest extends BaseModuleWebContextSensitiveTes
 		ModelAndView modelAndView = controller.handleRequest(request, response);
 		
 		ProgramWorkflow command = (ProgramWorkflow) modelAndView.getModel().get("workflow");
-		Assert.assertNotNull(command.getProgramWorkflowId());
+		Assertions.assertNotNull(command.getProgramWorkflowId());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/controller/provider/ProviderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/provider/ProviderFormControllerTest.java
@@ -11,15 +11,15 @@ package org.openmrs.web.controller.provider;
 
 import java.util.Arrays;
 
-import junit.framework.Assert;
+import org.junit.jupiter.api.Assertions;
 
 import org.hibernate.ObjectNotFoundException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Provider;
 import org.openmrs.ProviderAttribute;
 import org.openmrs.ProviderAttributeType;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindException;
@@ -54,8 +54,8 @@ public class ProviderFormControllerTest extends BaseModuleWebContextSensitiveTes
 		        .getBean("providerFormController");
 		providerFormController.onSubmit(mockHttpServletRequest, "save", null, null, null, provider, errors,
 		    createModelMap(providerAttributeType));
-		Assert.assertFalse(((ProviderAttribute) (provider.getAttributes().toArray()[0])).getVoided());
-		Assert.assertEquals(1, provider.getAttributes().size());
+		Assertions.assertFalse(((ProviderAttribute) (provider.getAttributes().toArray()[0])).getVoided());
+		Assertions.assertEquals(1, provider.getAttributes().size());
 		
 	}
 	
@@ -79,8 +79,8 @@ public class ProviderFormControllerTest extends BaseModuleWebContextSensitiveTes
 		        .getBean("providerFormController");
 		providerFormController.onSubmit(mockHttpServletRequest, "save", null, null, null, provider, errors,
 		    createModelMap(providerAttributeType));
-		Assert.assertEquals(1, provider.getAttributes().size());
-		Assert.assertTrue(((ProviderAttribute) (provider.getAttributes().toArray()[0])).isVoided());
+		Assertions.assertEquals(1, provider.getAttributes().size());
+		Assertions.assertTrue(((ProviderAttribute) (provider.getAttributes().toArray()[0])).isVoided());
 		
 	}
 	

--- a/omod/src/test/java/org/openmrs/web/controller/user/ChangePasswordFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/user/ChangePasswordFormControllerTest.java
@@ -9,18 +9,18 @@
  */
 package org.openmrs.web.controller.user;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.servlet.http.HttpSession;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.openmrs.web.user.UserProperties;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.validation.BindException;

--- a/omod/src/test/java/org/openmrs/web/controller/user/RoleFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/user/RoleFormControllerTest.java
@@ -11,12 +11,12 @@ package org.openmrs.web.controller.user;
 
 import java.util.HashSet;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Role;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.openmrs.web.test.WebTestHelper;
 import org.openmrs.web.test.WebTestHelper.Response;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +54,7 @@ public class RoleFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		
 		wth.handle(requestPOST);
 		
-		Assert.assertEquals("updated child", getUS().getRole("child").getDescription());
+		Assertions.assertEquals("updated child", getUS().getRole("child").getDescription());
 		
 		deleteAllData();
 	}

--- a/omod/src/test/java/org/openmrs/web/controller/user/UserFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/user/UserFormControllerTest.java
@@ -9,14 +9,14 @@
  */
 package org.openmrs.web.controller.user;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.openmrs.PersonName;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -64,7 +64,7 @@ public class UserFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		WebRequest request = new ServletWebRequest(new MockHttpServletRequest());
 		//A user with userId=2 is preset in the Test DataSet and the relevant details are passed
 		User user = Context.getUserService().getUser(2);
-		Assert.assertTrue(Context.getProviderService().getProvidersByPerson(user.getPerson()).isEmpty());
+		Assertions.assertTrue(Context.getProviderService().getProvidersByPerson(user.getPerson()).isEmpty());
 		ModelMap model = new ModelMap();
 		model.addAttribute("isProvider", false);
 		MockHttpServletResponse response = new MockHttpServletResponse();
@@ -72,8 +72,8 @@ public class UserFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		controller.handleSubmission(request, new MockHttpSession(), new ModelMap(), "", null, "Test1234",
 		    "valid secret question", "valid secret answer", "Test1234", false, new String[] { "Provider" }, "true",
 		    "addToProviderTable", user, new BindException(user, "user"), response);
-		Assert.assertFalse(Context.getProviderService().getProvidersByPerson(user.getPerson()).isEmpty());
-		Assert.assertEquals(200, response.getStatus());
+		Assertions.assertFalse(Context.getProviderService().getProvidersByPerson(user.getPerson()).isEmpty());
+		Assertions.assertEquals(200, response.getStatus());
 	}
 	
 	@Test
@@ -86,7 +86,7 @@ public class UserFormControllerTest extends BaseModuleWebContextSensitiveTest {
 		controller.handleSubmission(request, new MockHttpSession(), new ModelMap(), "", null, "Test123",
 		    "valid secret question", "valid secret answer", "Test1234", false, new String[] { "Provider" }, "true",
 		    "addToProviderTable", user, new BindException(user, "user"), response);
-		Assert.assertEquals(400, response.getStatus());
+		Assertions.assertEquals(400, response.getStatus());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/controller/user/UserListControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/user/UserListControllerTest.java
@@ -11,11 +11,11 @@ package org.openmrs.web.controller.user;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Role;
 import org.openmrs.User;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.ui.ModelMap;
 
 /**
@@ -31,7 +31,7 @@ public class UserListControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void displayUsers_shouldGetAllUsersIfNoNameGiven() {
 		UserListController controller = new UserListController();
 		List<User> users = controller.getUsers("Search", "", null, false);
-		Assert.assertEquals(2, users.size());
+		Assertions.assertEquals(2, users.size());
 	}
 	
 	/**
@@ -42,7 +42,7 @@ public class UserListControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void displayUsers_shouldGetUsersJustGivenActionParameter() {
 		UserListController controller = new UserListController();
 		List<User> users = controller.getUsers("Search", null, null, null);
-		Assert.assertEquals(2, users.size());
+		Assertions.assertEquals(2, users.size());
 	}
 	
 	/**
@@ -53,7 +53,7 @@ public class UserListControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void displayUsers_shouldGetUsersWithAGivenRole() {
 		UserListController controller = new UserListController();
 		List<User> users = controller.getUsers("Search", null, new Role("Provider"), null);
-		Assert.assertEquals(1, users.size());
+		Assertions.assertEquals(1, users.size());
 	}
 	
 	/**
@@ -64,6 +64,6 @@ public class UserListControllerTest extends BaseModuleWebContextSensitiveTest {
 	public void displayUsers_shouldIncludeDisabledUsersIfRequested() {
 		UserListController controller = new UserListController();
 		List<User> users = controller.getUsers("Search", "", new Role(""), true);
-		Assert.assertEquals(3, users.size());
+		Assertions.assertEquals(3, users.size());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/ConceptListItemTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/ConceptListItemTest.java
@@ -9,11 +9,11 @@
  */
 package org.openmrs.web.dwr;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Locale;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptClass;
 import org.openmrs.ConceptDatatype;

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRConceptServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRConceptServiceTest.java
@@ -15,9 +15,9 @@ import java.util.List;
 import java.util.Locale;
 
 import org.hibernate.Hibernate;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.GlobalProperty;
@@ -25,13 +25,13 @@ import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 	
 	private DWRConceptService dwrConceptService = new DWRConceptService();
 	
-	@Before
+	@BeforeEach
 	public void before() throws Exception {
 		executeDataSet("org/openmrs/web/dwr/include/DWRConceptServiceTest-coded-concept-with-no-answers.xml");
 		updateSearchIndex();
@@ -59,8 +59,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		Concept expected = Context.getConceptService().getConcept(phrase);
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null, null, null,
 		    null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -77,8 +77,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeClassNames.add("Question");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, includeClassNames, null, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -96,8 +96,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeClassNames.add("test");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, includeClassNames, null, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -114,8 +114,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		excludeClassNames.add("Question");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, excludeClassNames, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -132,8 +132,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeDatatypes.add("Coded");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, includeDatatypes,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -151,8 +151,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeDatatypes.add("test");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, includeDatatypes,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -169,8 +169,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		excludeDatatypes.add("Coded");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null,
 		    excludeDatatypes, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -230,11 +230,11 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		List<Object> findConceptAnswers = dwrConceptService.findConceptAnswers("T", 21, false, true);
 		
 		//then
-		Assert.assertEquals(2, findConceptAnswers.size());
+		Assertions.assertEquals(2, findConceptAnswers.size());
 		for (Object findConceptAnswer : findConceptAnswers) {
 			ConceptListItem answer = (ConceptListItem) findConceptAnswer;
 			if (!answer.getConceptId().equals(7) && !answer.getConceptId().equals(8)) {
-				Assert.fail("Should have found an answer with id 7 or 8");
+				Assertions.fail("Should have found an answer with id 7 or 8");
 			}
 		}
 	}
@@ -268,11 +268,11 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		List<Object> findConceptAnswers = dwrConceptService.findConceptAnswers("T", 21, false, true);
 		
 		//then
-		Assert.assertEquals(1, findConceptAnswers.size());
+		Assertions.assertEquals(1, findConceptAnswers.size());
 		for (Object findConceptAnswer : findConceptAnswers) {
 			ConceptListItem answer = (ConceptListItem) findConceptAnswer;
 			if (!answer.getConceptId().equals(7)) {
-				Assert.fail("Should have found an answer with id 7");
+				Assertions.fail("Should have found an answer with id 7");
 			}
 		}
 		
@@ -284,9 +284,9 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		Concept expected = Context.getConceptService().getConcept(phrase);
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null, null, null,
 		    null);
-		Assert.assertNotNull(result);
-		Assert.assertEquals(1, result.size());
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertEquals(1, result.size());
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	//Tests for search by Concept's UUID
@@ -302,8 +302,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		Concept expected = Context.getConceptService().getConceptByUuid(phrase);
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null, null, null,
 		    null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -320,8 +320,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeClassNames.add("Question");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, includeClassNames, null, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -339,8 +339,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeClassNames.add("test");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, includeClassNames, null, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -357,8 +357,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		excludeClassNames.add("Question");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, excludeClassNames, null,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -375,8 +375,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeDatatypes.add("Coded");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, includeDatatypes,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -394,8 +394,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		includeDatatypes.add("test");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, includeDatatypes,
 		    null, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -412,8 +412,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		excludeDatatypes.add("Coded");
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null,
 		    excludeDatatypes, null, null);
-		Assert.assertNotNull(result);
-		Assert.assertFalse(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertFalse(isConceptFound(expected, result));
 	}
 	
 	/**
@@ -427,8 +427,8 @@ public class DWRConceptServiceTest extends BaseModuleWebContextSensitiveTest {
 		Concept expected = Context.getConceptService().getConceptByUuid(phrase);
 		List<Object> result = dwrConceptService.findBatchOfConcepts(phrase, Boolean.FALSE, null, null, null, null, null,
 		    null);
-		Assert.assertNotNull(result);
-		Assert.assertEquals(1, result.size());
-		Assert.assertTrue(isConceptFound(expected, result));
+		Assertions.assertNotNull(result);
+		Assertions.assertEquals(1, result.size());
+		Assertions.assertTrue(isConceptFound(expected, result));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.web.dwr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.Obs;
 import org.openmrs.Person;
@@ -24,7 +24,7 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest {
 	

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRPatientServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRPatientServiceTest.java
@@ -13,15 +13,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 /**
  * Test the methods in {@link DWRPatientsServiceTest}
@@ -32,28 +32,28 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 	 * @see DWRPatientService#findPatients(String,boolean)
 	 */
 	// ignoring this test until we refactor person/patient/user
-	@Ignore
+	@Disabled
 	@Test
 	@Verifies(value = "should get results for patients that have edited themselves", method = "findPatients(String,null)")
 	public void findPatients_shouldGetResultsForPatientsThatHaveEditedThemselves() throws Exception {
 		executeDataSet("org/openmrs/web/dwr/include/DWRPatientService-patientisauser.xml");
 		DWRPatientService dwrService = new DWRPatientService();
 		Collection<Object> resultObjects = dwrService.findPatients("Other", false);
-		Assert.assertEquals(1, resultObjects.size());
+		Assertions.assertEquals(1, resultObjects.size());
 	}
 	
 	/**
 	 * @see DWRPatientService#findPatients(String,null)
 	 */
 	// ignoring this test until we refactor person/patient/user
-	@Ignore
+	@Disabled
 	@Test
 	@Verifies(value = "should logged in user should load their own patient object", method = "findPatients(String,null)")
 	public void findPatients_shouldLoggedInUserShouldLoadTheirOwnPatientObject() throws Exception {
 		executeDataSet("org/openmrs/web/dwr/include/DWRPatientService-patientisauser.xml");
 		DWRPatientService dwrService = new DWRPatientService();
 		Collection<Object> resultObjects = dwrService.findPatients("Super", false);
-		Assert.assertEquals(1, resultObjects.size());
+		Assertions.assertEquals(1, resultObjects.size());
 	}
 	
 	/**
@@ -64,9 +64,9 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 	public void findCountAndPatients_shouldNotSignalForANewSearchIfItIsNotTheFirstAjaxCall() throws Exception {
 		DWRPatientService dwrService = new DWRPatientService();
 		Map<String, Object> resultObjects = dwrService.findCountAndPatients("Joht", 1, 10, true);
-		Assert.assertEquals(0, resultObjects.get("count"));
-		Assert.assertNull(resultObjects.get("searchAgain"));
-		Assert.assertNull(resultObjects.get("notification"));
+		Assertions.assertEquals(0, resultObjects.get("count"));
+		Assertions.assertNull(resultObjects.get("searchAgain"));
+		Assertions.assertNull(resultObjects.get("notification"));
 	}
 	
 	/**
@@ -77,9 +77,9 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 	public void findCountAndPatients_shouldNotSignalForANewSearchIfTheNewSearchValueHasNoMatches() throws Exception {
 		DWRPatientService dwrService = new DWRPatientService();
 		Map<String, Object> resultObjects = dwrService.findCountAndPatients("Jopt", 0, 10, true);
-		Assert.assertEquals(0, resultObjects.get("count"));
-		Assert.assertNull(resultObjects.get("searchAgain"));
-		Assert.assertNull(resultObjects.get("notification"));
+		Assertions.assertEquals(0, resultObjects.get("count"));
+		Assertions.assertNull(resultObjects.get("searchAgain"));
+		Assertions.assertNull(resultObjects.get("notification"));
 	}
 	
 	/**
@@ -91,9 +91,9 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 	        throws Exception {
 		DWRPatientService dwrService = new DWRPatientService();
 		Map<String, Object> resultObjects = dwrService.findCountAndPatients("Joht", 0, 10, true);
-		Assert.assertEquals(0, resultObjects.get("count"));
-		Assert.assertEquals("Joh", resultObjects.get("searchAgain"));
-		Assert.assertNotNull(resultObjects.get("notification"));
+		Assertions.assertEquals(0, resultObjects.get("count"));
+		Assertions.assertEquals("Joh", resultObjects.get("searchAgain"));
+		Assertions.assertNotNull(resultObjects.get("notification"));
 	}
 	
 	/**
@@ -105,7 +105,7 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 		PatientService ps = Context.getPatientService();
 		final String identifier = "XYZ";
 		//should have no patient with this identifiers
-		Assert.assertEquals(0, ps.getCountOfPatients(identifier).intValue());
+		Assertions.assertEquals(0, ps.getCountOfPatients(identifier).intValue());
 		
 		Patient patient = ps.getPatient(2);
 		PatientIdentifier pId = new PatientIdentifier(identifier, ps.getPatientIdentifierType(5), Context
@@ -117,8 +117,8 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 		//Let's do this in a case insensitive way
 		Map<String, Object> resultObjects = new DWRPatientService().findCountAndPatients(identifier.toLowerCase(), 0, null,
 		    true);
-		Assert.assertEquals(1, resultObjects.get("count"));
-		Assert.assertEquals(1, ((List<?>) resultObjects.get("objectList")).size());
+		Assertions.assertEquals(1, resultObjects.get("count"));
+		Assertions.assertEquals(1, ((List<?>) resultObjects.get("objectList")).size());
 	}
 	
 	/**
@@ -131,7 +131,7 @@ public class DWRPatientServiceTest extends BaseModuleWebContextSensitiveTest {
 		DWRPatientService dwrService = new DWRPatientService();
 		Collection<Object> resultObjects = dwrService
 		        .findPatientsByIdentifier(new String[] { "Identifier1", "Identifier2" });
-		Assert.assertEquals(2, resultObjects.size());
+		Assertions.assertEquals(2, resultObjects.size());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRPersonServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRPersonServiceTest.java
@@ -11,10 +11,10 @@ package org.openmrs.web.dwr;
 
 import java.util.List;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 /**
  * Test the different aspects of {@link DWRPersonService}
@@ -31,8 +31,8 @@ public class DWRPersonServiceTest extends BaseModuleWebContextSensitiveTest {
 		
 		List<Object> persons = dwrPersonService.findPeopleByRoles("12345K", false, null);
 		
-		Assert.assertEquals(1, persons.size());
-		Assert.assertEquals(new PersonListItem(6), persons.get(0));
+		Assertions.assertEquals(1, persons.size());
+		Assertions.assertEquals(new PersonListItem(6), persons.get(0));
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRProgramWorkflowServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRProgramWorkflowServiceTest.java
@@ -9,17 +9,17 @@
  */
 package org.openmrs.web.dwr;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import java.util.Vector;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptName;
 import org.openmrs.PatientProgram;
@@ -28,7 +28,7 @@ import org.openmrs.ProgramWorkflow;
 import org.openmrs.ProgramWorkflowState;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class DWRProgramWorkflowServiceTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -38,7 +38,7 @@ public class DWRProgramWorkflowServiceTest extends BaseModuleWebContextSensitive
 	
 	protected static final String PROGRAM_NEXT_STATES_XML = "org/openmrs/web/dwr/include/DWRProgramWorkflowServiceTest-initialStates.xml";
 	
-	@Before
+	@BeforeEach
 	public void setUp() throws Exception {
 		dwrProgramWorkflowService = new DWRProgramWorkflowService();
 		executeDataSet(PROGRAM_WITH_OUTCOMES_XML);

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRProviderServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRProviderServiceTest.java
@@ -17,11 +17,11 @@ import java.util.Vector;
 import org.apache.commons.collections.Closure;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.Predicate;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -31,7 +31,7 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	
 	private DWRProviderService service;
 	
-	@Before
+	@BeforeEach
 	public void setup() throws Exception {
 		service = new DWRProviderService();
 		
@@ -47,7 +47,7 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	public void findProvider_shouldReturnAMessageWithNoMatchesFoundWhenNoProvidersAreFound() throws Exception {
 		Vector<Object> providers = service.findProvider("noProvider", false, 0, 1);
 		
-		Assert.assertEquals("Provider.noMatchesFound", ((String) providers.get(0)));
+		Assertions.assertEquals("Provider.noMatchesFound", ((String) providers.get(0)));
 	}
 	
 	/**
@@ -60,9 +60,9 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	        throws Exception {
 		
 		Vector<Object> providers = service.findProvider("provider", true, 0, 10);
-		Assert.assertEquals(4, providers.size());
+		Assertions.assertEquals(4, providers.size());
 		
-		Assert.assertTrue(CollectionUtils.exists(providers, new Predicate() {
+		Assertions.assertTrue(CollectionUtils.exists(providers, new Predicate() {
 			
 			@Override
 			public boolean evaluate(Object object) {
@@ -79,7 +79,7 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	public void findProvider_shouldReturnTheListOfProvidersMatchingTheSearchName() throws Exception {
 		
 		Vector<Object> providers = service.findProvider("provider", false, 0, 10);
-		Assert.assertEquals(2, providers.size());
+		Assertions.assertEquals(2, providers.size());
 		
 		final ArrayList<String> providerNames = new ArrayList<String>();
 		
@@ -91,7 +91,7 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 			}
 		});
 		
-		Assert.assertTrue(providerNames.containsAll(Arrays.asList("Bruno Otterbourg", "Hippocrates of Cos")));
+		Assertions.assertTrue(providerNames.containsAll(Arrays.asList("Bruno Otterbourg", "Hippocrates of Cos")));
 	}
 	
 	/**
@@ -100,12 +100,12 @@ public class DWRProviderServiceTest extends BaseModuleWebContextSensitiveTest {
 	 *           list
 	 */
 	@Test
-	@Ignore("This test fails because we have the order by for person names mentioned in the person.hbm.xml for the names set. "
+	@Disabled("This test fails because we have the order by for person names mentioned in the person.hbm.xml for the names set. "
 	        + "H2 is expecting a group by clause for all the columns mentioned in the order by which is not needed to execute a query in mysql."
 	        + "Keeping the test case here because this might be a problem in other databases too")
 	public void findProviderCountAndProvider_shouldReturnTheCountOfAllProvidersMatchingTheSearchedNameAlongWithProviderList()
 	        throws Exception {
 		Map<String, Object> countAndProviders = service.findProviderCountAndProvider("provider", true, 0, 2);
-		Assert.assertEquals(3, countAndProviders.get("count"));
+		Assertions.assertEquals(3, countAndProviders.get("count"));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/DeprecationCheckTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DeprecationCheckTest.java
@@ -9,14 +9,14 @@
  */
 package org.openmrs.web.dwr;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;

--- a/omod/src/test/java/org/openmrs/web/dwr/PersonListItemTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/PersonListItemTest.java
@@ -11,12 +11,12 @@ package org.openmrs.web.dwr;
 
 import java.util.Map;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Person;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 /**
  * Tests the {@link PersonListItem} class.
@@ -31,9 +31,9 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	public void PersonListItem_shouldIdentifyBestMatchingNameForTheFamilyName() throws Exception {
 		
 		PersonListItem listItem = new PersonListItem(Context.getPersonService().getPerson(2), "hornblower3");
-		Assert.assertEquals("Hornblower3", listItem.getFamilyName());
-		Assert.assertEquals("John", listItem.getGivenName());
-		Assert.assertEquals("Peeter", listItem.getMiddleName());
+		Assertions.assertEquals("Hornblower3", listItem.getFamilyName());
+		Assertions.assertEquals("John", listItem.getGivenName());
+		Assertions.assertEquals("Peeter", listItem.getMiddleName());
 	}
 	
 	/**
@@ -45,9 +45,9 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	        throws Exception {
 		
 		PersonListItem listItem = new PersonListItem(Context.getPersonService().getPerson(2), "Horatio");
-		Assert.assertEquals("Hornblower", listItem.getFamilyName());
-		Assert.assertEquals("Horatio", listItem.getGivenName());
-		Assert.assertEquals("Test", listItem.getMiddleName());
+		Assertions.assertEquals("Hornblower", listItem.getFamilyName());
+		Assertions.assertEquals("Horatio", listItem.getGivenName());
+		Assertions.assertEquals("Test", listItem.getMiddleName());
 	}
 	
 	/**
@@ -58,9 +58,9 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	public void PersonListItem_shouldIdentifyBestMatchingNameAsOtherNameForTheMiddleName() throws Exception {
 		
 		PersonListItem listItem = new PersonListItem(Context.getPersonService().getPerson(2), "Peeter");
-		Assert.assertEquals("Hornblower2", listItem.getFamilyName());
-		Assert.assertEquals("Horatio", listItem.getGivenName());
-		Assert.assertEquals("Peeter", listItem.getMiddleName());
+		Assertions.assertEquals("Hornblower2", listItem.getFamilyName());
+		Assertions.assertEquals("Horatio", listItem.getGivenName());
+		Assertions.assertEquals("Peeter", listItem.getMiddleName());
 	}
 	
 	/**
@@ -71,9 +71,9 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	public void PersonListItem_shouldIdentifyBestMatchingNameAsOtherNameForTheGivenName() throws Exception {
 		
 		PersonListItem listItem = new PersonListItem(Context.getPersonService().getPerson(2), "joh");
-		Assert.assertEquals("Hornblower3", listItem.getFamilyName());
-		Assert.assertEquals("John", listItem.getGivenName());
-		Assert.assertEquals("Peeter", listItem.getMiddleName());
+		Assertions.assertEquals("Hornblower3", listItem.getFamilyName());
+		Assertions.assertEquals("John", listItem.getGivenName());
+		Assertions.assertEquals("Peeter", listItem.getMiddleName());
 	}
 	
 	/**
@@ -84,9 +84,9 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	public void PersonListItem_shouldIdentifyBestMatchingNameInMultipleSearchNames() throws Exception {
 		
 		PersonListItem listItem = new PersonListItem(Context.getPersonService().getPerson(2), "Horn peet john");
-		Assert.assertEquals("Hornblower3", listItem.getFamilyName());
-		Assert.assertEquals("John", listItem.getGivenName());
-		Assert.assertEquals("Peeter", listItem.getMiddleName());
+		Assertions.assertEquals("Hornblower3", listItem.getFamilyName());
+		Assertions.assertEquals("John", listItem.getGivenName());
+		Assertions.assertEquals("Peeter", listItem.getMiddleName());
 	}
 	
 	/**
@@ -99,13 +99,13 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 		
 		for (Map.Entry<String, String> entry : listItem.getAttributes().entrySet()) {
 			if (entry.getKey().equals("Civil Status")) {
-				Assert.assertEquals("MARRIED", entry.getValue()); // should be string not conceptId
+				Assertions.assertEquals("MARRIED", entry.getValue()); // should be string not conceptId
 				return; // quit after we test the first one
 			}
 		}
 		
 		// make sure we found at least one attr
-		Assert.fail("No civil status person attribute was defined");
+		Assertions.fail("No civil status person attribute was defined");
 	}
 	
 	/**
@@ -125,7 +125,7 @@ public class PersonListItemTest extends BaseModuleWebContextSensitiveTest {
 	@Verifies(value = "should return PersonListItem given person parameter", method = "createBestMatch(Person)")
 	public void createBestMatch_shouldReturnPersonListItemGivenPersonParameter() throws Exception {
 		PersonListItem listItem = PersonListItem.createBestMatch(Context.getPersonService().getPerson(2));
-		Assert.assertTrue(listItem instanceof PersonListItem);
+		Assertions.assertTrue(listItem instanceof PersonListItem);
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/ProviderListItemTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/ProviderListItemTest.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.web.dwr;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Person;
 import org.openmrs.PersonName;
 import org.openmrs.Provider;
@@ -23,7 +23,7 @@ public class ProviderListItemTest {
 	private Provider provider;
 	
 	@SuppressWarnings("serial")
-	@Before
+	@BeforeEach
 	public void setup() {
 		provider = new Provider() {
 			
@@ -59,7 +59,7 @@ public class ProviderListItemTest {
 	public void getDisplayName_shouldReturnADisplayNameBasedOnWhetherProviderHasAPersonAssociated() throws Exception {
 		
 		ProviderListItem providerListItem = new ProviderListItem(provider);
-		Assert.assertEquals("givenName middleName familyName", providerListItem.getDisplayName());
+		Assertions.assertEquals("givenName middleName familyName", providerListItem.getDisplayName());
 	}
 	
 	/**
@@ -73,7 +73,7 @@ public class ProviderListItemTest {
 		Provider provider = new Provider();
 		provider.setIdentifier("identifier");
 		ProviderListItem providerListItem = new ProviderListItem(provider);
-		Assert.assertEquals("identifier", providerListItem.getIdentifier());
+		Assertions.assertEquals("identifier", providerListItem.getIdentifier());
 	}
 	
 	/**
@@ -85,7 +85,7 @@ public class ProviderListItemTest {
 		provider.setProviderId(2);
 		
 		ProviderListItem providerListItem = new ProviderListItem(provider);
-		Assert.assertEquals(Integer.valueOf(2), providerListItem.getProviderId());
+		Assertions.assertEquals(Integer.valueOf(2), providerListItem.getProviderId());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/patient/PatientDashboardGraphControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/patient/PatientDashboardGraphControllerTest.java
@@ -11,12 +11,12 @@ package org.openmrs.web.patient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.controller.patient.PatientDashboardGraphController;
 import org.openmrs.web.controller.patient.PatientGraphData;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.ui.ModelMap;
 
 import java.util.Calendar;
@@ -56,10 +56,10 @@ public class PatientDashboardGraphControllerTest extends BaseModuleWebContextSen
 		JsonNode expectedJson = mapper.readTree(expectedData);
 		JsonNode actualJson = mapper.readTree(graph.toString());
 		
-		Assert.assertEquals(expectedJson.size(), actualJson.size());
+		Assertions.assertEquals(expectedJson.size(), actualJson.size());
 		for (Iterator<String> fieldNames = expectedJson.fieldNames(); fieldNames.hasNext();) {
 			String field = fieldNames.next();
-			Assert.assertEquals(expectedJson.get(field), actualJson.get(field));
+			Assertions.assertEquals(expectedJson.get(field), actualJson.get(field));
 		}
 	}
 	
@@ -72,7 +72,7 @@ public class PatientDashboardGraphControllerTest extends BaseModuleWebContextSen
 	@Verifies(value = "return form for rendering the json data", method = "showGraphData(Integer, Integer, ModelMap)")
 	public void shouldDisplayPatientDashboardGraphForm() throws Exception {
 		executeDataSet("org/openmrs/api/include/ObsServiceTest-initial.xml");
-		Assert.assertEquals("module/legacyui/patientGraphJsonForm",
+		Assertions.assertEquals("module/legacyui/patientGraphJsonForm",
 		    new PatientDashboardGraphController().showGraphData(2, 1, new ModelMap()));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/servlet/DownloadDictionaryServletTest.java
+++ b/omod/src/test/java/org/openmrs/web/servlet/DownloadDictionaryServletTest.java
@@ -14,14 +14,14 @@ import java.util.List;
 
 import jakarta.annotation.Resource;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.openmrs.Concept;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.db.ConceptDAO;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -49,7 +49,7 @@ public class DownloadDictionaryServletTest extends BaseModuleWebContextSensitive
 		        + "3,\"COUGH SYRUP\",\"This is used for coughs\",\"COUGH SYRUP\",\"\",\"\",\"Drug\",\"N/A\",\"\",\"Super User\"\n"
 		        + "5,\"SINGLE\",\"Some description\",\"SINGLE\",\"\",\"\",\"Misc\",\"N/A\",\"\",\"Super User\"\n"
 		        + "6,\"MARRIED\",\"Some description\",\"MARRIED\",\"\",\"\",\"Misc\",\"N/A\",\"\",\"Super User\"\n";
-		Assert.assertEquals(expectedContent, actualContent);
+		Assertions.assertEquals(expectedContent, actualContent);
 	}
 	
 	@Test
@@ -90,7 +90,7 @@ public class DownloadDictionaryServletTest extends BaseModuleWebContextSensitive
 	public void shouldPrintColumnsWithEmptyQuotesForNullFields() throws Exception {
 		String actualContent = runServletWithConcepts(new Concept(1));
 		String expectedContent = EXPECTED_HEADER + "1,\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\"\n";
-		Assert.assertEquals(expectedContent, actualContent);
+		Assertions.assertEquals(expectedContent, actualContent);
 	}
 	
 	private String runServletWithConcepts(Concept... concepts) throws Exception {
@@ -108,23 +108,23 @@ public class DownloadDictionaryServletTest extends BaseModuleWebContextSensitive
 	}
 	
 	private void assertContent(String expectedStart, String expectedEnd, String[] expectedLineSections, String actualContent) {
-		Assert.assertTrue(actualContent.startsWith(expectedStart));
-		Assert.assertTrue(actualContent.endsWith(expectedEnd));
+		Assertions.assertTrue(actualContent.startsWith(expectedStart));
+		Assertions.assertTrue(actualContent.endsWith(expectedEnd));
 		
 		// The content with line breaks can come in any order so test for the content flexibly
 		String lineBreakContent = actualContent.substring(expectedStart.length(),
 		    actualContent.length() - expectedEnd.length());
 		
 		// Should start and end with "
-		Assert.assertTrue(lineBreakContent.startsWith("\""));
-		Assert.assertTrue(lineBreakContent.endsWith("\""));
+		Assertions.assertTrue(lineBreakContent.startsWith("\""));
+		Assertions.assertTrue(lineBreakContent.endsWith("\""));
 		
 		lineBreakContent = lineBreakContent.replace("\"", "");
 		List<String> actualLineBreakSections = Arrays.asList(lineBreakContent.split("\n"));
 		
-		Assert.assertEquals(expectedLineSections.length, actualLineBreakSections.size());
+		Assertions.assertEquals(expectedLineSections.length, actualLineBreakSections.size());
 		for (String expectedSection : expectedLineSections) {
-			Assert.assertTrue(actualLineBreakSections.contains(expectedSection));
+			Assertions.assertTrue(actualLineBreakSections.contains(expectedSection));
 		}
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/servlet/LoginServletTest.java
+++ b/omod/src/test/java/org/openmrs/web/servlet/LoginServletTest.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.web.servlet;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -39,7 +39,7 @@ public class LoginServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		loginServlet.service(request, response);
 		
-		Assert.assertEquals("/somecontextpath/login.htm", response.getRedirectedUrl());
+		Assertions.assertEquals("/somecontextpath/login.htm", response.getRedirectedUrl());
 	}
 	
 	/**
@@ -53,7 +53,7 @@ public class LoginServletTest extends BaseModuleWebContextSensitiveTest {
 		// this test depends on being able to log in as "admin:test".
 		Context.logout();
 		Context.authenticate("admin", "test");
-		Assert.assertTrue(Context.isAuthenticated());
+		Assertions.assertTrue(Context.isAuthenticated());
 		
 		// do the test now
 		LoginServlet loginServlet = new LoginServlet();
@@ -66,7 +66,7 @@ public class LoginServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		loginServlet.service(request, response);
 		
-		Assert.assertNotSame("/somecontextpath/login.htm", response.getRedirectedUrl());
+		Assertions.assertNotSame("/somecontextpath/login.htm", response.getRedirectedUrl());
 	}
 	
 	/**
@@ -79,7 +79,7 @@ public class LoginServletTest extends BaseModuleWebContextSensitiveTest {
 		// this test depends on being able to log in as "admin:test".
 		Context.logout();
 		Context.authenticate("admin", "test");
-		Assert.assertTrue(Context.isAuthenticated());
+		Assertions.assertTrue(Context.isAuthenticated());
 		
 		// do the test now
 		LoginServlet loginServlet = new LoginServlet();
@@ -105,6 +105,6 @@ public class LoginServletTest extends BaseModuleWebContextSensitiveTest {
 		request.setParameter("pw", "test");
 		loginServlet.service(request, response);
 		
-		Assert.assertNotSame("/somecontextpath/login.htm", response.getRedirectedUrl());
+		Assertions.assertNotSame("/somecontextpath/login.htm", response.getRedirectedUrl());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/servlet/ShowGraphServletTest.java
+++ b/omod/src/test/java/org/openmrs/web/servlet/ShowGraphServletTest.java
@@ -15,10 +15,10 @@ import java.util.Date;
 import jakarta.servlet.http.HttpServletRequest;
 
 import org.jfree.chart.JFreeChart;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
@@ -39,7 +39,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		JFreeChart chart = new ShowGraphServlet().getChart(request);
 		
-		Assert.assertEquals("CUSTOM UNITS", chart.getXYPlot().getRangeAxis().getLabel());
+		Assertions.assertEquals("CUSTOM UNITS", chart.getXYPlot().getRangeAxis().getLabel());
 	}
 	
 	/**
@@ -54,7 +54,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		JFreeChart chart = new ShowGraphServlet().getChart(request);
 		
-		Assert.assertEquals("cells/mmL", chart.getXYPlot().getRangeAxis().getLabel());
+		Assertions.assertEquals("cells/mmL", chart.getXYPlot().getRangeAxis().getLabel());
 	}
 	
 	/**
@@ -69,7 +69,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		Date fromDate = new ShowGraphServlet().getFromDate(null);
 		
-		Assert.assertEquals(lastYear.getTimeInMillis(), fromDate.getTime(), 1000);
+		Assertions.assertEquals(lastYear.getTimeInMillis(), fromDate.getTime(), 1000);
 	}
 	
 	/**
@@ -80,7 +80,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 	public void getFromDate_shouldReturnSameDateAsGivenStringParameter() throws Exception {
 		Long time = new Date().getTime() - 100000;
 		Date fromDate = new ShowGraphServlet().getFromDate(Long.toString(time));
-		Assert.assertEquals(time.longValue(), fromDate.getTime());
+		Assertions.assertEquals(time.longValue(), fromDate.getTime());
 	}
 	
 	/**
@@ -95,7 +95,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		Date toDate = new ShowGraphServlet().getToDate(null);
 		
-		Assert.assertEquals(nxtMonth.getTimeInMillis(), toDate.getTime(), 1000);
+		Assertions.assertEquals(nxtMonth.getTimeInMillis(), toDate.getTime(), 1000);
 	}
 	
 	/**
@@ -111,7 +111,7 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 		
 		Date toDate = new ShowGraphServlet().getToDate(Long.toString(time));
 		
-		Assert.assertEquals(timeCal.getTimeInMillis(), toDate.getTime());
+		Assertions.assertEquals(timeCal.getTimeInMillis(), toDate.getTime());
 	}
 	
 	/**
@@ -121,9 +121,9 @@ public class ShowGraphServletTest extends BaseModuleWebContextSensitiveTest {
 	@Verifies(value = "should set hour minute and second to zero", method = "getToDate(String)")
 	public void getToDate_shouldSetHourMinuteAndSecondToZero() throws Exception {
 		Date toDate = new ShowGraphServlet().getToDate(Long.toString(new Date().getTime()));
-		Assert.assertEquals(0, toDate.getHours());
-		Assert.assertEquals(0, toDate.getMinutes());
-		Assert.assertEquals(0, toDate.getSeconds());
+		Assertions.assertEquals(0, toDate.getHours());
+		Assertions.assertEquals(0, toDate.getMinutes());
+		Assertions.assertEquals(0, toDate.getSeconds());
 	}
 	
 }

--- a/omod/src/test/java/org/openmrs/web/taglib/ForEachEncounterTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/ForEachEncounterTagTest.java
@@ -15,13 +15,13 @@ import java.util.List;
 import jakarta.servlet.jsp.tagext.BodyTag;
 import jakarta.servlet.jsp.tagext.Tag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockPageContext;
 
 /**
@@ -47,13 +47,13 @@ public class ForEachEncounterTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setVar("enc");
 		tag.setNum(num);
 		// the tag passes
-		Assert.assertEquals(BodyTag.EVAL_BODY_BUFFERED, tag.doStartTag());
+		Assertions.assertEquals(BodyTag.EVAL_BODY_BUFFERED, tag.doStartTag());
 		//the match count should not exceed the limit
-		Assert.assertTrue(num >= tag.matchingEncs.size());
+		Assertions.assertTrue(num >= tag.matchingEncs.size());
 		//check the sorting
-		Assert.assertEquals(11, tag.matchingEncs.get(0).getId().intValue());
-		Assert.assertEquals(16, tag.matchingEncs.get(1).getId().intValue());
-		Assert.assertEquals(7, tag.matchingEncs.get(2).getId().intValue());
+		Assertions.assertEquals(11, tag.matchingEncs.get(0).getId().intValue());
+		Assertions.assertEquals(16, tag.matchingEncs.get(1).getId().intValue());
+		Assertions.assertEquals(7, tag.matchingEncs.get(2).getId().intValue());
 	}
 	
 	/**
@@ -66,6 +66,6 @@ public class ForEachEncounterTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setPageContext(new MockPageContext());
 		tag.setEncounters(new ArrayList<Encounter>());
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/taglib/FormatTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/FormatTagTest.java
@@ -15,8 +15,9 @@ import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
 import org.hamcrest.Matchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.Concept;
 import org.openmrs.ConceptDescription;
 import org.openmrs.ConceptName;
@@ -25,7 +26,7 @@ import org.openmrs.api.ConceptNameType;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockPageContext;
 
 public class FormatTagTest extends BaseModuleWebContextSensitiveTest {
@@ -72,7 +73,7 @@ public class FormatTagTest extends BaseModuleWebContextSensitiveTest {
 		format.setWithConceptNameTag(withTag);
 		StringBuilder sb = new StringBuilder();
 		format.printConcept(sb, concept);
-		Assert.assertEquals(expected, sb.toString());
+		Assertions.assertEquals(expected, sb.toString());
 	}
 	
 	/**
@@ -101,7 +102,7 @@ public class FormatTagTest extends BaseModuleWebContextSensitiveTest {
 		StringBuilder sb = new StringBuilder();
 		format.printConcept(sb, c);
 		
-		Assert.assertThat(sb.toString(), Matchers.not(Matchers.containsString("<script>")));
+		MatcherAssert.assertThat(sb.toString(), Matchers.not(Matchers.containsString("<script>")));
 	}
 	
 	/**
@@ -179,8 +180,8 @@ public class FormatTagTest extends BaseModuleWebContextSensitiveTest {
 	 */
 	private void checkStartTagEvaluation(PageContext pageContext, FormatTag tag, Object object, String expected) {
 		tag.setObject(object);
-		Assert.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
-		Assert.assertNotNull(pageContext.getAttribute(ATTRIBUTE_OBJECT_VALUE));
-		Assert.assertEquals(expected, pageContext.getAttribute(ATTRIBUTE_OBJECT_VALUE));
+		Assertions.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
+		Assertions.assertNotNull(pageContext.getAttribute(ATTRIBUTE_OBJECT_VALUE));
+		Assertions.assertEquals(expected, pageContext.getAttribute(ATTRIBUTE_OBJECT_VALUE));
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/taglib/OpenmrsHtmlEscapingAwareTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/OpenmrsHtmlEscapingAwareTagTest.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.web.taglib;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 
 public class OpenmrsHtmlEscapingAwareTagTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -50,6 +50,6 @@ public class OpenmrsHtmlEscapingAwareTagTest extends BaseModuleWebContextSensiti
 		
 		objectUnderTest.setHtmlEscape(setValue);
 		
-		Assert.assertEquals(expectedValue, objectUnderTest.isHtmlEscape());
+		Assertions.assertEquals(expectedValue, objectUnderTest.isHtmlEscape());
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
@@ -14,12 +14,12 @@ import java.util.Locale;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.Verifies;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.beans.BeansException;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.mock.web.MockBodyContent;
@@ -46,7 +46,7 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 	
 	private MockPageContext mockPageContext;
 	
-	@Before
+	@BeforeEach
 	public void createMockPageContext() throws Exception {
 		
 		MockServletContext sc = new MockServletContext();
@@ -263,7 +263,7 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 		try {
 			openmrsMessageTag.doEndTag();
 			
-			Assert.assertTrue("doEndTag should have thrown an exception", false);
+			Assertions.assertTrue(false, "doEndTag should have thrown an exception");
 		}
 		catch (Exception e) {
 			//Do nothing.  Test successful
@@ -274,8 +274,8 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 		final int tagReturnValue = openmrsMessageTag.doEndTag();
 		final String output = (String) mockPageContext.getAttribute(varName, scope);
 		
-		Assert.assertEquals("Tag should return 'EVAL_PAGE'", TagSupport.EVAL_PAGE, tagReturnValue);
-		Assert.assertEquals(String.format("Variable '%s' should be '%s'", varName, expectedOutput), output, expectedOutput);
+		Assertions.assertEquals(TagSupport.EVAL_PAGE, tagReturnValue, "Tag should return 'EVAL_PAGE'");
+		Assertions.assertEquals(output, expectedOutput, String.format("Variable '%s' should be '%s'", varName, expectedOutput));
 	}
 	
 	/**
@@ -289,8 +289,8 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 		int tagReturnValue = openmrsMessageTag.doEndTag();
 		String output = ((MockHttpServletResponse) mockPageContext.getResponse()).getContentAsString();
 		
-		Assert.assertEquals("Tag should return 'EVAL_PAGE'", TagSupport.EVAL_PAGE, tagReturnValue);
-		Assert.assertEquals(String.format("Output should be '%s'", expectedOutput), expectedOutput, output);
+		Assertions.assertEquals(TagSupport.EVAL_PAGE, tagReturnValue, "Tag should return 'EVAL_PAGE'");
+		Assertions.assertEquals(expectedOutput, output, String.format("Output should be '%s'", expectedOutput));
 	}
 	
 	/**

--- a/omod/src/test/java/org/openmrs/web/taglib/PortletTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/PortletTagTest.java
@@ -9,7 +9,7 @@
  */
 package org.openmrs.web.taglib;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,7 +17,7 @@ import org.openmrs.module.Module;
 import org.openmrs.module.ModuleFactory;
 import org.openmrs.test.Verifies;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mockStatic;
 
 /**

--- a/omod/src/test/java/org/openmrs/web/taglib/PrivilegeTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/PrivilegeTagTest.java
@@ -9,13 +9,13 @@
  */
 package org.openmrs.web.taglib;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.SkipBaseSetup;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockPageContext;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import static org.hamcrest.core.Is.is;
 

--- a/omod/src/test/java/org/openmrs/web/taglib/RequireTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/RequireTagTest.java
@@ -12,13 +12,13 @@ package org.openmrs.web.taglib;
 import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.Tag;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.openmrs.api.context.Context;
 import org.openmrs.test.SkipBaseSetup;
 import org.openmrs.test.Verifies;
 import org.openmrs.web.WebConstants;
-import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockPageContext;
 
@@ -43,7 +43,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setAnyPrivilege("Manage WhirleyGigs, Manage WhoopDeDoos");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -64,7 +64,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setAllPrivileges("Manage WhirleyGigs, Manage WhoopDeDoos, Manage Thingamajigs");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -85,7 +85,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setPrivilege("Manage WhirleyGigs");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_BODY, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -106,7 +106,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setAllPrivileges("Manage WhirleyGigs, Manage WhoopDeDoos, Manage Thingamajigs");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -127,7 +127,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setAnyPrivilege("Random Privilege, Other Random Privilege");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -148,7 +148,7 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setPrivilege("Some Random Privilege");
 		
 		// the tag passes
-		Assert.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
+		Assertions.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
 		
 		Context.logout();
 	}
@@ -173,10 +173,10 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		String redirect = "/myRedirect.html";
 		tag.setRedirect(redirect);
 		
-		Assert.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
-		Assert.assertEquals(true, pageContext.getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, PageContext.SESSION_SCOPE));
-		Assert.assertNotNull(pageContext.getAttribute(WebConstants.REQUIRED_PRIVILEGES, PageContext.SESSION_SCOPE));
-		Assert.assertEquals(redirect, pageContext.getAttribute(WebConstants.DENIED_PAGE, PageContext.SESSION_SCOPE)
+		Assertions.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
+		Assertions.assertEquals(true, pageContext.getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, PageContext.SESSION_SCOPE));
+		Assertions.assertNotNull(pageContext.getAttribute(WebConstants.REQUIRED_PRIVILEGES, PageContext.SESSION_SCOPE));
+		Assertions.assertEquals(redirect, pageContext.getAttribute(WebConstants.DENIED_PAGE, PageContext.SESSION_SCOPE)
 		        .toString());
 		
 		Context.logout();
@@ -201,10 +201,10 @@ public class RequireTagTest extends BaseModuleWebContextSensitiveTest {
 		tag.setAllPrivileges("Manage WhirleyGigs,Manage Thingamajigs");
 		tag.setRedirect("");
 		
-		Assert.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
-		Assert.assertEquals(true, pageContext.getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, PageContext.SESSION_SCOPE));
-		Assert.assertNotNull(pageContext.getAttribute(WebConstants.REQUIRED_PRIVILEGES, PageContext.SESSION_SCOPE));
-		Assert.assertEquals(referer, pageContext.getAttribute(WebConstants.DENIED_PAGE, PageContext.SESSION_SCOPE)
+		Assertions.assertEquals(Tag.SKIP_PAGE, tag.doStartTag());
+		Assertions.assertEquals(true, pageContext.getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, PageContext.SESSION_SCOPE));
+		Assertions.assertNotNull(pageContext.getAttribute(WebConstants.REQUIRED_PRIVILEGES, PageContext.SESSION_SCOPE));
+		Assertions.assertEquals(referer, pageContext.getAttribute(WebConstants.DENIED_PAGE, PageContext.SESSION_SCOPE)
 		        .toString());
 		
 		Context.logout();

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
 				<plugin>
 				    <groupId>org.apache.maven.plugins</groupId>
 				    <artifactId>maven-surefire-plugin</artifactId>
-				    <version>2.22.1</version>
+				    <version>3.5.2</version>
 				    <configuration>
 				    	<argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
 				    </configuration>


### PR DESCRIPTION
## Summary

Migrates all ~70 test files in the omod module from JUnit 4 to JUnit 5 (Jupiter) to align with openmrs-core 3.0.0-SNAPSHOT which has completed its JUnit 5 migration.

## Changes

### Import migrations
- `org.junit.Test` → `org.junit.jupiter.api.Test`
- `org.junit.Assert` → `org.junit.jupiter.api.Assertions`
- `org.junit.Before` / `@Before` → `org.junit.jupiter.api.BeforeEach` / `@BeforeEach`
- `org.junit.After` / `@After` → `org.junit.jupiter.api.AfterEach` / `@AfterEach`
- `org.junit.Ignore` / `@Ignore` → `org.junit.jupiter.api.Disabled` / `@Disabled`
- `junit.framework.Assert` → `org.junit.jupiter.api.Assertions`
- `org.junit.Assert.assertThat` → `org.hamcrest.MatcherAssert.assertThat`
- `org.mockito.Matchers` → `org.mockito.ArgumentMatchers`

### Base test class updates
- `org.openmrs.web.test.BaseModuleWebContextSensitiveTest` → `org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest`
- `org.openmrs.web.test.BaseWebContextSensitiveTest` → `org.openmrs.web.test.jupiter.BaseWebContextSensitiveTest`

### Pattern replacements
- `@Rule ExpectedException` → `Assertions.assertThrows()`
- `@Test(expected = X.class)` → `Assertions.assertThrows()`
- JUnit 4 assertion message parameter order (first → last)

### Build configuration
- Upgraded `maven-surefire-plugin` from 2.22.1 to 3.5.2
- Added aligned JUnit Platform 6.0.3 dependencies to resolve version mismatch with JUnit Jupiter 6.0.3

### Mockito cleanup
- Removed unnecessary stubs causing `UnnecessaryStubbingException` under JUnit 5's stricter Mockito defaults

## Test results

```
Tests run: 366, Failures: 0, Errors: 0, Skipped: 3
BUILD SUCCESS
```