### PR TITLE
Pass secrets to reusable workflow for Maven SNAPSHOT deployment

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,3 +14,7 @@ jobs:
     with:
       java_versions: '[21, 25]'
       main_java_version: '21'
+    secrets:
+      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+      MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}


### PR DESCRIPTION
## Problem

The CI build ([run #497](https://github.com/openmrs/openmrs-module-legacyui/actions/runs/22877805619/job/66374154304)) fails during the Maven deploy step with a **401 Unauthorized** error because `MAVEN_REPO_USERNAME` and `MAVEN_REPO_API_KEY` are empty.

The reusable workflow `build-backend-module.yml` expects these secrets to authenticate with the OpenMRS Maven snapshot repository, but `maven.yml` was not forwarding any secrets.

## Fix

Add `secrets: inherit` to pass organization-level secrets to the reusable workflow.