### PR TITLE
AOM-182: Replace deprecated Boolean constructor usage in ConceptProposalListController

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
@@ -49,7 +49,7 @@ public class ConceptProposalListController extends SimpleFormController {
 		if (Context.isAuthenticated()) {
 			ConceptService cs = Context.getConceptService();
 			log.debug("tmp value: " + request.getParameter("includeCompleted"));
-			boolean b = new Boolean(request.getParameter("includeCompleted"));
+			boolean b = Boolean.parseBoolean(request.getParameter("includeCompleted"));
 			log.debug("b value: " + b);
 			cpList = cs.getAllConceptProposals(b);
 		}
@@ -64,7 +64,7 @@ public class ConceptProposalListController extends SimpleFormController {
 			origText.put(cp.getOriginalText(), matchingProposals);
 		}
 		
-		boolean asc = new Boolean("asc".equals(request.getParameter("sortOrder")));
+		boolean asc = "asc".equals(request.getParameter("sortOrder"));
 		String sortOn = request.getParameter("sortOn");
 		if (sortOn == null) {
 			sortOn = "occurences";


### PR DESCRIPTION
## Description
Replaced deprecated Boolean constructor usage in ConceptProposalListController.

## Changes Made
- Replaced new Boolean(String) with Boolean.parseBoolean(String)
- Removed unnecessary Boolean wrapping for boolean expressions

## Impact
- Eliminates deprecated API usage
- Improves code quality and readability
- No functional changes

## Ticket
https://openmrs.atlassian.net/browse/AOM-182