### PR TITLE
AOM-184: Replace deprecated Boolean constructor in PatientFormController

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
@@ -308,8 +308,12 @@ public class OptionsFormController extends SimpleFormController {
 			opts.setDefaultLocation(props.get(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCATION));
 			opts.setDefaultLocale(props.get(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE));
 			opts.setProficientLocales(props.get(OpenmrsConstants.USER_PROPERTY_PROFICIENT_LOCALES));
-			opts.setShowRetiredMessage(new Boolean(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_RETIRED)));
-			opts.setVerbose(new Boolean(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_VERBOSE)));
+            opts.setShowRetiredMessage(Boolean.parseBoolean(
+                    String.valueOf(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_RETIRED))
+            ));
+            opts.setVerbose(Boolean.parseBoolean(
+                    String.valueOf(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_VERBOSE))
+            ));
 			opts.setUsername(user.getUsername());
 			
 			PersonName personName;

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
@@ -49,7 +49,7 @@ public class ConceptProposalListController extends SimpleFormController {
 		if (Context.isAuthenticated()) {
 			ConceptService cs = Context.getConceptService();
 			log.debug("tmp value: " + request.getParameter("includeCompleted"));
-			boolean b = new Boolean(request.getParameter("includeCompleted"));
+			boolean b = Boolean.parseBoolean(request.getParameter("includeCompleted"));
 			log.debug("b value: " + b);
 			cpList = cs.getAllConceptProposals(b);
 		}
@@ -64,7 +64,7 @@ public class ConceptProposalListController extends SimpleFormController {
 			origText.put(cp.getOriginalText(), matchingProposals);
 		}
 		
-		boolean asc = new Boolean("asc".equals(request.getParameter("sortOrder")));
+		boolean asc = "asc".equals(request.getParameter("sortOrder"));
 		String sortOn = request.getParameter("sortOn");
 		if (sortOn == null) {
 			sortOn = "occurences";

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
@@ -156,7 +156,7 @@ public class PatientFormController extends PersonFormController {
 								pi.setLocation(ls.getLocation(Integer.valueOf(locs[i])));
 							}
 							if (idPrefStatus != null && idPrefStatus.length > i) {
-								pi.setPreferred(new Boolean(idPrefStatus[i]));
+								pi.setPreferred(Boolean.parseBoolean(idPrefStatus[i]));
 							}
 							
 							BindException piErrors = new BindException(pi, "patientIdentifier");


### PR DESCRIPTION
## Description

This PR replaces the deprecated `new Boolean(String)` constructor in PatientFormController with `Boolean.parseBoolean(String)`.

The deprecated constructor is marked for removal in newer Java versions and may lead to unnecessary object creation.

## Changes

- Replaced:
  - `new Boolean(idPrefStatus[i])`
- With:
  - `Boolean.parseBoolean(idPrefStatus[i])`

## Impact

- No functional changes
- Improves code quality and compatibility with modern Java versions

## Testing

- Built successfully using:
  mvn clean install -DskipTests

## Ticket

https://openmrs.atlassian.net/browse/AOM-184