### PR TITLE
AOM-186: Replace deprecated Boolean constructor in PersonFormController.

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
@@ -308,8 +308,12 @@ public class OptionsFormController extends SimpleFormController {
 			opts.setDefaultLocation(props.get(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCATION));
 			opts.setDefaultLocale(props.get(OpenmrsConstants.USER_PROPERTY_DEFAULT_LOCALE));
 			opts.setProficientLocales(props.get(OpenmrsConstants.USER_PROPERTY_PROFICIENT_LOCALES));
-			opts.setShowRetiredMessage(new Boolean(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_RETIRED)));
-			opts.setVerbose(new Boolean(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_VERBOSE)));
+            opts.setShowRetiredMessage(Boolean.parseBoolean(
+                    String.valueOf(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_RETIRED))
+            ));
+            opts.setVerbose(Boolean.parseBoolean(
+                    String.valueOf(props.get(OpenmrsConstants.USER_PROPERTY_SHOW_VERBOSE))
+            ));
 			opts.setUsername(user.getUsername());
 			
 			PersonName personName;

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
@@ -49,7 +49,7 @@ public class ConceptProposalListController extends SimpleFormController {
 		if (Context.isAuthenticated()) {
 			ConceptService cs = Context.getConceptService();
 			log.debug("tmp value: " + request.getParameter("includeCompleted"));
-			boolean b = new Boolean(request.getParameter("includeCompleted"));
+			boolean b = Boolean.parseBoolean(request.getParameter("includeCompleted"));
 			log.debug("b value: " + b);
 			cpList = cs.getAllConceptProposals(b);
 		}
@@ -64,7 +64,7 @@ public class ConceptProposalListController extends SimpleFormController {
 			origText.put(cp.getOriginalText(), matchingProposals);
 		}
 		
-		boolean asc = new Boolean("asc".equals(request.getParameter("sortOrder")));
+		boolean asc = "asc".equals(request.getParameter("sortOrder"));
 		String sortOn = request.getParameter("sortOn");
 		if (sortOn == null) {
 			sortOn = "occurences";

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
@@ -156,7 +156,7 @@ public class PatientFormController extends PersonFormController {
 								pi.setLocation(ls.getLocation(Integer.valueOf(locs[i])));
 							}
 							if (idPrefStatus != null && idPrefStatus.length > i) {
-								pi.setPreferred(new Boolean(idPrefStatus[i]));
+								pi.setPreferred(Boolean.parseBoolean(idPrefStatus[i]));
 							}
 							
 							BindException piErrors = new BindException(pi, "patientIdentifier");

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
@@ -488,7 +488,7 @@ public class PersonFormController extends SimpleFormController {
 				if (!"".equals(gNames[i])) { //skips invalid and blank address data box
 					PersonName pn = new PersonName();
 					if (namePrefStatus != null && namePrefStatus.length > i) {
-						pn.setPreferred(new Boolean(namePrefStatus[i]));
+						pn.setPreferred(Boolean.parseBoolean(namePrefStatus[i]));
 					}
 					if (gNames.length >= i + 1) {
 						pn.setGivenName(gNames[i]);
@@ -645,7 +645,7 @@ public class PersonFormController extends SimpleFormController {
 					pa.setAddress3(add3s[i]);
 				}
 				if (addPrefStatus != null && addPrefStatus.length > i) {
-					pa.setPreferred(new Boolean(addPrefStatus[i]));
+					pa.setPreferred(Boolean.parseBoolean(addPrefStatus[i]));
 				}
 				if (add6s.length >= i + 1) {
 					pa.setAddress6(add6s[i]);


### PR DESCRIPTION
## Description

This PR replaces usage of the deprecated Boolean constructor in PersonFormController.

Specifically, occurrences of:

    new Boolean(String)

have been replaced with:

    Boolean.parseBoolean(String)

This change ensures compatibility with newer Java versions and avoids unnecessary object creation.

## Changes
- Updated all deprecated Boolean constructor usages in PersonFormController
- Replaced with Boolean.parseBoolean for safe and efficient parsing

## Impact
- No functional changes
- Improves code quality and future compatibility

## JIRA Ticket
https://openmrs.atlassian.net/browse/AOM-186