### PR TITLE
AOM-185 Replace deprecated Boolean constructor in PersonFormController

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
@@ -491,7 +491,7 @@ public class PersonFormController extends SimpleFormController {
 				if (!"".equals(gNames[i])) { //skips invalid and blank address data box
 					PersonName pn = new PersonName();
 					if (namePrefStatus != null && namePrefStatus.length > i) {
-						pn.setPreferred(new Boolean(namePrefStatus[i]));
+						pn.setPreferred(Boolean.parseBoolean(namePrefStatus[i]));
 					}
 					if (gNames.length >= i + 1) {
 						pn.setGivenName(gNames[i]);
@@ -648,7 +648,7 @@ public class PersonFormController extends SimpleFormController {
 					pa.setAddress3(add3s[i]);
 				}
 				if (addPrefStatus != null && addPrefStatus.length > i) {
-					pa.setPreferred(new Boolean(addPrefStatus[i]));
+					pa.setPreferred(Boolean.parseBoolean(addPrefStatus[i]));
 				}
 				if (add6s.length >= i + 1) {
 					pa.setAddress6(add6s[i]);


### PR DESCRIPTION
Replaced deprecated new Boolean(String) constructor usages in PersonFormController with Boolean.parseBoolean(String).

During testing: 
- Built the project locally
- Ran the test suite before the change
- Ran the test suite after the change
- Existing test failures remained unchanged