### PR TITLE
LUI-213: Support viewing archived observations in Legacy UI

### DIFF
--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -315,7 +315,7 @@ public class EncounterFormController extends SimpleFormController {
 			map.put("encounterRoles", es.getAllEncounterRoles(false));
 			map.put("forms", Context.getFormService().getAllForms());
 			// loop over the encounter's observations to find the edited obs
-			for (Obs o : encounter.getObsAtTopLevel(true)) {
+			for (Obs o : encounter.getAllObsIncludingArchived()) {
 				
 				// only edited obs has previous version
 				if (o.hasPreviousVersion()) {

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -295,6 +295,7 @@ public class EncounterFormController extends SimpleFormController {
 			obsMapToReturn = new TreeMap<FormField, List<Obs>>(new NumberingFormFieldComparator()); // use custom comparator
 		}
 		
+
 		if (Context.isAuthenticated()) {
 			EncounterService es = Context.getEncounterService();
 			FormService fs = Context.getFormService();
@@ -320,9 +321,14 @@ public class EncounterFormController extends SimpleFormController {
 					List<Obs> list = groupMembersMap.get(parent);
 					if (list == null) {
 						list = new ArrayList<Obs>();
+						if (parent.hasGroupMembers()) {
+							list.addAll(parent.getGroupMembers(true));
+						}
 						groupMembersMap.put(parent, list);
 					}
-					list.add(o);
+					if (!list.contains(o)) {
+						list.add(o);
+					}
 					continue;
 				}
 				
@@ -349,6 +355,7 @@ public class EncounterFormController extends SimpleFormController {
 		}
 		
 		if (log.isDebugEnabled()) {
+			log.error("Total obs: " + encounter.getAllObsIncludingArchived().size());
 			log.debug("setting obsMap in page context (size: " + obsMapToReturn.size() + ")");
 		}
 		map.put("obsMap", obsMapToReturn);

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -355,7 +355,6 @@ public class EncounterFormController extends SimpleFormController {
 		}
 		
 		if (log.isDebugEnabled()) {
-			log.error("Total obs: " + encounter.getAllObsIncludingArchived().size());
 			log.debug("setting obsMap in page context (size: " + obsMapToReturn.size() + ")");
 		}
 		map.put("obsMap", obsMapToReturn);

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -295,11 +295,6 @@ public class EncounterFormController extends SimpleFormController {
 			obsMapToReturn = new TreeMap<FormField, List<Obs>>(new NumberingFormFieldComparator()); // use custom comparator
 		}
 		
-		// this maps the obs to form field objects for non top-level obs
-		// it is keyed on obs so that when looping over an exploded obsGroup
-		// the formfield can be fetched easily (in order to show the field numbers etc)
-		Map<Obs, FormField> otherFormFields = new HashMap<Obs, FormField>();
-		
 		if (Context.isAuthenticated()) {
 			EncounterService es = Context.getEncounterService();
 			FormService fs = Context.getFormService();
@@ -357,9 +352,6 @@ public class EncounterFormController extends SimpleFormController {
 			log.debug("setting obsMap in page context (size: " + obsMapToReturn.size() + ")");
 		}
 		map.put("obsMap", obsMapToReturn);
-		
-		map.put("otherFormFields", otherFormFields);
-		
 		map.put("locale", Context.getLocale());
 		map.put("editedObs", editedObs);
 		if (encounter.getPatient() != null) {

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -314,8 +314,22 @@ public class EncounterFormController extends SimpleFormController {
 			
 			map.put("encounterRoles", es.getAllEncounterRoles(false));
 			map.put("forms", Context.getFormService().getAllForms());
+			
+			Map<Obs, List<Obs>> groupMembersMap = new HashMap<Obs, List<Obs>>();
+			
 			// loop over the encounter's observations to find the edited obs
 			for (Obs o : encounter.getAllObsIncludingArchived()) {
+				
+				Obs parent = o.getObsGroup();
+				if (parent != null) {
+					List<Obs> list = groupMembersMap.get(parent);
+					if (list == null) {
+						list = new ArrayList<Obs>();
+						groupMembersMap.put(parent, list);
+					}
+					list.add(o);
+					continue;
+				}
 				
 				// only edited obs has previous version
 				if (o.hasPreviousVersion()) {
@@ -328,22 +342,15 @@ public class EncounterFormController extends SimpleFormController {
 					ff = new FormField();
 				}
 				
-				// we only put the top-level obs in the obsMap.  Those would
-				// be the obs that don't have an obs grouper 
-				if (o.getObsGroup() == null) {
-					// populate the obs map with this formfield and obs
-					List<Obs> list = obsMapToReturn.get(ff);
-					if (list == null) {
-						list = new Vector<Obs>();
-						obsMapToReturn.put(ff, list);
-					}
-					list.add(o);
-				} else {
-					// this is not a top-level obs, just put the formField
-					// in a separate list and be done with it
-					otherFormFields.put(o, ff);
+				// populate the obs map with this formfield and obs
+				List<Obs> list = obsMapToReturn.get(ff);
+				if (list == null) {
+					list = new Vector<Obs>();
+					obsMapToReturn.put(ff, list);
 				}
+				list.add(o);
 			}
+			map.put("groupMembersMap", groupMembersMap);
 		}
 		
 		if (log.isDebugEnabled()) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -11,7 +11,9 @@ package org.openmrs.web.dwr;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.Vector;
@@ -29,6 +31,7 @@ import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.impl.ObsArchiveHelper;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.security.RequirePrivilege;
@@ -317,13 +320,23 @@ public class DWRObsService {
 		
 		if (p != null && c != null) {
 			log.debug("Getting obss with patient and concept");
-			obss = Context.getObsService().getObservationsByPersonAndConcept(p, c);
+			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
+			    Collections.singletonList(p), null, Collections.singletonList(c), null, null, null, null, null, null, null, null, true));
+			ObsArchiveHelper archiveHelper = Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			if (archiveHelper != null) {
+				obss.addAll(archiveHelper.getArchivedObsByPersonIdAndConceptId(p.getPersonId(), c.getConceptId()));
+			}
 		} else if (e != null) {
 			log.debug("Getting obss by encounter");
-			obss = e.getAllObs();
+			obss = e.getAllObsIncludingArchived();
 		} else if (p != null) {
 			log.debug("Getting obss with just patient");
-			obss = Context.getObsService().getObservationsByPerson(p);
+			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
+			    Collections.singletonList(p), null, null, null, null, null, null, null, null, null, null, true));
+			ObsArchiveHelper archiveHelper = Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			if (archiveHelper != null) {
+				obss.addAll(archiveHelper.getArchivedObsByPersonId(p.getPersonId()));
+			}
 		}
 		
 		if (obss != null) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -35,7 +35,6 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.ObsArchiveHelper;
-import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.security.RequirePrivilege;
@@ -330,7 +329,7 @@ public class DWRObsService {
 			e = Context.getEncounterService().getEncounter(eId);
 		}
 		
-		Collection<Obs> obss = null;
+		List<Obs> obss = null;
 		
 		if (p != null && c != null) {
 			log.debug("Getting obss with patient and concept");
@@ -340,11 +339,11 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonIdAndConceptId(p.getPersonId(), c.getConceptId()));
 			}
-			sortObservations((List<Obs>) obss);
+			sortObservations(obss);
 		} else if (e != null) {
 			log.debug("Getting obss by encounter");
 			obss = new ArrayList<Obs>(e.getAllObsIncludingArchived());
-			sortObservations((List<Obs>) obss);
+			sortObservations(obss);
 		} else if (p != null) {
 			log.debug("Getting obss with just patient");
 			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
@@ -353,7 +352,7 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonId(p.getPersonId()));
 			}
-			sortObservations((List<Obs>) obss);
+			sortObservations(obss);
 		}
 		
 		if (obss != null) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -30,8 +30,10 @@ import org.openmrs.Location;
 import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.api.AdministrationService;
+import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.impl.ObsArchiveHelper;
+import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
 import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.security.RequirePrivilege;
@@ -93,6 +95,20 @@ public class DWRObsService {
 		}
 		
 		return obsList;
+	}
+
+	private ObsArchiveHelper getObsArchiveHelperSafely() {
+		try {
+			String lastProcessedId = Context.getAdministrationService()
+			        .getGlobalProperty(OpenmrsConstants.GP_OBS_ARCHIVE_LAST_PROCESSED_OBS_ID);
+			if (lastProcessedId != null && !lastProcessedId.trim().isEmpty()) {
+				return Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			}
+		}
+		catch (APIException e) {
+			// archive table may not exist yet or context not available, degrade gracefully
+		}
+		return null;
 	}
 	
 	/**
@@ -322,7 +338,7 @@ public class DWRObsService {
 			log.debug("Getting obss with patient and concept");
 			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
 			    Collections.singletonList(p), null, Collections.singletonList(c), null, null, null, null, null, null, null, null, true));
-			ObsArchiveHelper archiveHelper = Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			ObsArchiveHelper archiveHelper = getObsArchiveHelperSafely();
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonIdAndConceptId(p.getPersonId(), c.getConceptId()));
 			}
@@ -333,7 +349,7 @@ public class DWRObsService {
 			log.debug("Getting obss with just patient");
 			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
 			    Collections.singletonList(p), null, null, null, null, null, null, null, null, null, null, true));
-			ObsArchiveHelper archiveHelper = Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
+			ObsArchiveHelper archiveHelper = getObsArchiveHelperSafely();
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonId(p.getPersonId()));
 			}

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -101,14 +101,10 @@ public class DWRObsService {
 
 	private ObsArchiveHelper getObsArchiveHelperSafely() {
 		try {
-			String lastProcessedId = Context.getAdministrationService()
-			        .getGlobalProperty(OpenmrsConstants.GP_OBS_ARCHIVE_LAST_PROCESSED_OBS_ID);
-			if (lastProcessedId != null && !lastProcessedId.trim().isEmpty()) {
-				return Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
-			}
+			return Context.getRegisteredComponent("obsArchiveHelper", ObsArchiveHelper.class);
 		}
 		catch (APIException e) {
-			// archive table may not exist yet or context not available, degrade gracefully
+			// bean not registered on this core, degrade gracefully
 		}
 		return null;
 	}

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -342,6 +342,7 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonIdAndConceptId(p.getPersonId(), c.getConceptId()));
 			}
+			sortObservations((java.util.List<Obs>) obss);
 		} else if (e != null) {
 			log.debug("Getting obss by encounter");
 			obss = e.getAllObsIncludingArchived();
@@ -353,6 +354,7 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonId(p.getPersonId()));
 			}
+			sortObservations((java.util.List<Obs>) obss);
 		}
 		
 		if (obss != null) {
@@ -384,5 +386,18 @@ public class DWRObsService {
 		}
 		
 		return oItem;
+	}
+
+	private void sortObservations(java.util.List<Obs> obss) {
+		Collections.sort(obss, new java.util.Comparator<Obs>() {
+			@Override
+			public int compare(Obs o1, Obs o2) {
+				int result = OpenmrsUtil.compareWithNullAsEarliest(o2.getObsDatetime(), o1.getObsDatetime());
+				if (result == 0) {
+					return OpenmrsUtil.compareWithNullAsGreatest(o1.getObsId(), o2.getObsId());
+				}
+				return result;
+			}
+		});
 	}
 }

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -14,7 +14,9 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 
@@ -342,10 +344,11 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonIdAndConceptId(p.getPersonId(), c.getConceptId()));
 			}
-			sortObservations((java.util.List<Obs>) obss);
+			sortObservations((List<Obs>) obss);
 		} else if (e != null) {
 			log.debug("Getting obss by encounter");
-			obss = e.getAllObsIncludingArchived();
+			obss = new ArrayList<Obs>(e.getAllObsIncludingArchived());
+			sortObservations((List<Obs>) obss);
 		} else if (p != null) {
 			log.debug("Getting obss with just patient");
 			obss = new ArrayList<Obs>(Context.getObsService().getObservations(
@@ -354,7 +357,7 @@ public class DWRObsService {
 			if (archiveHelper != null) {
 				obss.addAll(archiveHelper.getArchivedObsByPersonId(p.getPersonId()));
 			}
-			sortObservations((java.util.List<Obs>) obss);
+			sortObservations((List<Obs>) obss);
 		}
 		
 		if (obss != null) {
@@ -388,8 +391,8 @@ public class DWRObsService {
 		return oItem;
 	}
 
-	private void sortObservations(java.util.List<Obs> obss) {
-		Collections.sort(obss, new java.util.Comparator<Obs>() {
+	private void sortObservations(List<Obs> obss) {
+		Collections.sort(obss, new Comparator<Obs>() {
 			@Override
 			public int compare(Obs o1, Obs o2) {
 				int result = OpenmrsUtil.compareWithNullAsEarliest(o2.getObsDatetime(), o1.getObsDatetime());

--- a/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
+++ b/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
@@ -15,7 +15,7 @@
 			<tr class="<c:if test="${obs.voided}">voided </c:if>">
 				<td colspan="5"><%-- this is the empty row to mimic the description row--%></td>
 			</tr>
-			<c:set var="obsList" value="${obs.groupMembers}" scope="request"/>
+			<c:set var="obsList" value="${groupMembersMap != null && groupMembersMap[obs] != null ? groupMembersMap[obs] : obs.groupMembers}" scope="request"/>
 			<c:set var="field" value="${otherFormFields[groupMember]}" scope="request"/>
 			<c:set var="level" value="${level+1}" scope="request"/>
 			<c:import url="obsDisplay.jsp" />

--- a/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
+++ b/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
@@ -16,6 +16,7 @@
 				<td colspan="5"><%-- this is the empty row to mimic the description row--%></td>
 			</tr>
 			<c:set var="obsList" value="${groupMembersMap != null && groupMembersMap[obs] != null ? groupMembersMap[obs] : obs.groupMembers}" scope="request"/>
+			<c:remove var="field" scope="request"/>
 			<c:set var="level" value="${level+1}" scope="request"/>
 			<c:import url="obsDisplay.jsp" />
 		</c:when>

--- a/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
+++ b/omod/src/main/webapp/admin/encounters/obsDisplay.jsp
@@ -7,7 +7,7 @@
 
 <c:forEach var="obs" items="${obsList}">
 	<c:choose>
-		<c:when test="${obs.obsGrouping}">
+		<c:when test="${obs.obsGrouping || (groupMembersMap != null && groupMembersMap[obs] != null)}">
 			<tr class="<c:if test="${obs.voided}">voided </c:if>obsGroupHeader">
 				<td>${field.fieldNumber}<c:if test="${field.fieldPart != null && field.fieldPart != ''}">.${field.fieldPart}</c:if></td>
 				<td colspan="4" style="padding-left: ${padding}"><c:out value="${field.field.concept.name.name}" /></td>
@@ -16,7 +16,6 @@
 				<td colspan="5"><%-- this is the empty row to mimic the description row--%></td>
 			</tr>
 			<c:set var="obsList" value="${groupMembersMap != null && groupMembersMap[obs] != null ? groupMembersMap[obs] : obs.groupMembers}" scope="request"/>
-			<c:set var="field" value="${otherFormFields[groupMember]}" scope="request"/>
 			<c:set var="level" value="${level+1}" scope="request"/>
 			<c:import url="obsDisplay.jsp" />
 		</c:when>

--- a/omod/src/main/webapp/resources/scripts/obs.js
+++ b/omod/src/main/webapp/resources/scripts/obs.js
@@ -56,6 +56,18 @@ function refreshObsTable(obss) {
 		dwr.util.removeAllRows(obsTableToRefresh);
 		if ( obss && obss.length > 0 ) {
 			dwr.util.addRows(obsTableToRefresh, obss, obsCellFuncs, {
+				rowCreator:function(options) {
+				    var tr = document.createElement("tr");
+				    if (options.rowNum % 2)
+				        tr.className = "oddRow";
+				    else
+				        tr.className = "evenRow";
+				        
+				    if (options.rowData && options.rowData.voided) {
+				        tr.className += " voided";
+				    }
+				    return tr;
+				},
 				cellCreator:function(options) {
 				    var td = document.createElement("td");
 				    return td;

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
@@ -74,39 +74,117 @@ public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTe
 		
 		try {
 			Context.getAdministrationService().executeSQL(
-				"INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (998, 2, 21, 3, '2026-01-01', 1, 'uuid-998', 1, '2026-01-01', 'FINAL')", false);
+			    "INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (998, 2, 21, 3, '2026-01-01', 1, 'uuid-998', 1, '2026-01-01', 'FINAL')",
+			    false);
 			Context.getAdministrationService().executeSQL(
-				"INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (999, 2, 21, 3, '2026-01-01', 1, 'uuid-999', 1, '2026-01-01', 'FINAL', 998)", false);
+			    "INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (999, 2, 21, 3, '2026-01-01', 1, 'uuid-999', 1, '2026-01-01', 'FINAL', 998)",
+			    false);
 			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
 			
 			EncounterFormController controller = new EncounterFormController();
 			MockHttpServletRequest request = new MockHttpServletRequest();
 			
-			Map<String, Object> map = controller.referenceData(request, encounter, new BindException(encounter, "encounter"));
+			Map<String, Object> map = controller.referenceData(request, encounter,
+			    new BindException(encounter, "encounter"));
 			
 			@SuppressWarnings("unchecked")
 			Map<Obs, List<Obs>> groupMembersMap = (Map<Obs, List<Obs>>) map.get("groupMembersMap");
 			
-			boolean foundArchivedParent = false;
-			boolean foundArchivedChild = false;
+			@SuppressWarnings("unchecked")
+			java.util.SortedMap<org.openmrs.FormField, List<Obs>> obsMap = (java.util.SortedMap<org.openmrs.FormField, List<Obs>>) map
+			        .get("obsMap");
 			
-			if (groupMembersMap != null) {
-				for (Map.Entry<Obs, List<Obs>> entry : groupMembersMap.entrySet()) {
-					if (entry.getKey().getObsId().equals(998)) {
-						foundArchivedParent = true;
-						for (Obs child : entry.getValue()) {
-							if (child.getObsId().equals(999)) {
-								foundArchivedChild = true;
-							}
+			Obs parent = null;
+			if (obsMap != null) {
+				for (List<Obs> list : obsMap.values()) {
+					for (Obs o : list) {
+						if (o.getObsId().equals(998)) {
+							parent = o;
+							break;
 						}
 					}
+					if (parent != null)
+						break;
 				}
 			}
 			
-			Assertions.assertTrue(foundArchivedParent, "Archived parent should be in groupMembersMap");
-			Assertions.assertTrue(foundArchivedChild, "Archived child should be in groupMembersMap");
-		} finally {
-			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id IN (998, 999)", false);
+			Assertions.assertNotNull(parent, "Archived parent should be in obsMap");
+			Assertions.assertFalse(parent.isObsGrouping(), "Parent has no live members, so isObsGrouping is false");
+			Assertions.assertNotNull(groupMembersMap.get(parent), "groupMembersMap must contain the parent to fix the gate");
+			
+			boolean foundArchivedChild = false;
+			for (Obs child : groupMembersMap.get(parent)) {
+				if (child.getObsId().equals(999)) {
+					foundArchivedChild = true;
+					break;
+				}
+			}
+			Assertions.assertTrue(foundArchivedChild, "Archived child should be in groupMembersMap for the parent");
+		}
+		finally {
+			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 999", false);
+			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 998", false);
+		}
+	}
+	
+	@Test
+	public void referenceData_shouldIncludeVoidedGroupMembersInMap() throws Exception {
+		executeDataSet(ENC_INITIAL_DATA_XML);
+		
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		
+		try {
+			Context.getAdministrationService().executeSQL(
+			    "INSERT INTO obs (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (997, 2, 21, 3, '2026-01-01', 0, 'uuid-997', 1, '2026-01-01', 'FINAL')",
+			    false);
+			Context.getAdministrationService().executeSQL(
+			    "INSERT INTO obs (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (996, 2, 21, 3, '2026-01-01', 1, 'uuid-996', 1, '2026-01-01', 'FINAL', 997)",
+			    false);
+			
+			EncounterFormController controller = new EncounterFormController();
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			
+			Map<String, Object> map = controller.referenceData(request, encounter,
+			    new BindException(encounter, "encounter"));
+			
+			@SuppressWarnings("unchecked")
+			Map<Obs, List<Obs>> groupMembersMap = (Map<Obs, List<Obs>>) map.get("groupMembersMap");
+			
+			@SuppressWarnings("unchecked")
+			java.util.SortedMap<org.openmrs.FormField, List<Obs>> obsMap = (java.util.SortedMap<org.openmrs.FormField, List<Obs>>) map
+			        .get("obsMap");
+			
+			Obs parent = null;
+			if (obsMap != null) {
+				for (List<Obs> list : obsMap.values()) {
+					for (Obs o : list) {
+						if (o.getObsId().equals(997)) {
+							parent = o;
+							break;
+						}
+					}
+					if (parent != null)
+						break;
+				}
+			}
+			
+			Assertions.assertNotNull(parent, "Live parent should be in obsMap");
+			Assertions.assertTrue(parent.isObsGrouping(), "Live parent has voided members, so isObsGrouping is true");
+			Assertions.assertFalse(parent.hasGroupMembers(), "Live parent has only voided members, so hasGroupMembers() (non-voided) is false");
+			Assertions.assertNotNull(groupMembersMap.get(parent), "groupMembersMap must contain the parent");
+			
+			boolean foundVoidedChild = false;
+			for (Obs child : groupMembersMap.get(parent)) {
+				if (child.getObsId().equals(996)) {
+					foundVoidedChild = true;
+					break;
+				}
+			}
+			Assertions.assertTrue(foundVoidedChild, "Voided child should be in groupMembersMap for the parent");
+		}
+		finally {
+			Context.getAdministrationService().executeSQL("DELETE FROM obs WHERE obs_id = 996", false);
+			Context.getAdministrationService().executeSQL("DELETE FROM obs WHERE obs_id = 997", false);
 		}
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
@@ -79,6 +79,8 @@ public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTe
 			Context.getAdministrationService().executeSQL(
 			    "INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (999, 2, 21, 3, '2026-01-01', 1, 'uuid-999', 1, '2026-01-01', 'FINAL', 998)",
 			    false);
+			Context.getRegisteredComponent("obsArchiveHelper", org.openmrs.api.impl.ObsArchiveHelper.class)
+			        .markArchiveHasData();
 			
 			EncounterFormController controller = new EncounterFormController();
 			MockHttpServletRequest request = new MockHttpServletRequest();

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
@@ -79,7 +79,6 @@ public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTe
 			Context.getAdministrationService().executeSQL(
 			    "INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (999, 2, 21, 3, '2026-01-01', 1, 'uuid-999', 1, '2026-01-01', 'FINAL', 998)",
 			    false);
-			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
 			
 			EncounterFormController controller = new EncounterFormController();
 			MockHttpServletRequest request = new MockHttpServletRequest();

--- a/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/encounter/EncounterFormControllerTest.java
@@ -21,6 +21,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.validation.BindException;
 
 import java.util.List;
+import java.util.Map;
+import org.openmrs.Obs;
 
 public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTest {
 	
@@ -62,5 +64,49 @@ public class EncounterFormControllerTest extends BaseModuleWebContextSensitiveTe
 		newEncounter = Context.getEncounterService().getEncountersByPatientId(newPatient.getPatientId());
 		Assertions.assertEquals(1, newEncounter.size());
 		Assertions.assertEquals(false, newEncounter.get(0).isVoided());
+	}
+	
+	@Test
+	public void referenceData_shouldIncludeFullyArchivedGroupMembersInMap() throws Exception {
+		executeDataSet(ENC_INITIAL_DATA_XML);
+		
+		Encounter encounter = Context.getEncounterService().getEncounter(3);
+		
+		try {
+			Context.getAdministrationService().executeSQL(
+				"INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (998, 2, 21, 3, '2026-01-01', 1, 'uuid-998', 1, '2026-01-01', 'FINAL')", false);
+			Context.getAdministrationService().executeSQL(
+				"INSERT INTO obs_archive (obs_id, person_id, concept_id, encounter_id, obs_datetime, voided, uuid, creator, date_created, status, obs_group_id) VALUES (999, 2, 21, 3, '2026-01-01', 1, 'uuid-999', 1, '2026-01-01', 'FINAL', 998)", false);
+			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
+			
+			EncounterFormController controller = new EncounterFormController();
+			MockHttpServletRequest request = new MockHttpServletRequest();
+			
+			Map<String, Object> map = controller.referenceData(request, encounter, new BindException(encounter, "encounter"));
+			
+			@SuppressWarnings("unchecked")
+			Map<Obs, List<Obs>> groupMembersMap = (Map<Obs, List<Obs>>) map.get("groupMembersMap");
+			
+			boolean foundArchivedParent = false;
+			boolean foundArchivedChild = false;
+			
+			if (groupMembersMap != null) {
+				for (Map.Entry<Obs, List<Obs>> entry : groupMembersMap.entrySet()) {
+					if (entry.getKey().getObsId().equals(998)) {
+						foundArchivedParent = true;
+						for (Obs child : entry.getValue()) {
+							if (child.getObsId().equals(999)) {
+								foundArchivedChild = true;
+							}
+						}
+					}
+				}
+			}
+			
+			Assertions.assertTrue(foundArchivedParent, "Archived parent should be in groupMembersMap");
+			Assertions.assertTrue(foundArchivedChild, "Archived child should be in groupMembersMap");
+		} finally {
+			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id IN (998, 999)", false);
+		}
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -230,6 +230,8 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 		try {
 			Context.getAdministrationService().executeSQL(
 				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2008-09-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
+			Context.getRegisteredComponent("obsArchiveHelper", org.openmrs.api.impl.ObsArchiveHelper.class)
+			        .markArchiveHasData();
 			
 			Vector<ObsListItem> items = dwrService.getObsByPatientConceptEncounter("2", "21", null);
 			

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -11,8 +11,10 @@ package org.openmrs.web.dwr;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Vector;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.jupiter.api.Test;
@@ -204,5 +206,34 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 		assertNotNull(addedObs);
 		assertNotNull(addedObs.getValueCoded());
 		assertEquals(booleanConcept, addedObs.getValueCoded());
+	}
+	
+	/**
+	 * @see org.openmrs.web.dwr.DWRObsService#getObsByPatientConceptEncounter(String, String, String)
+	 */
+	@Test
+	@Verifies(value = "should return archived obs and set voided flag", method = "getObsByPatientConceptEncounter(String, String, String)")
+	public void getObsByPatientConceptEncounter_shouldIncludeArchivedObs() throws Exception {
+		DWRObsService dwrService = new DWRObsService();
+		
+		try {
+			Context.getAdministrationService().executeSQL(
+				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2026-01-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
+			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
+			
+			Vector<ObsListItem> items = dwrService.getObsByPatientConceptEncounter("2", "21", null);
+			
+			boolean foundArchived = false;
+			for (ObsListItem obsItem : items) {
+				if (obsItem.getObsId().equals(999)) {
+					foundArchived = true;
+					assertTrue(obsItem.getVoided());
+				}
+			}
+			
+			assertTrue(foundArchived);
+		} finally {
+			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 999;", false);
+		}
 	}
 }

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -216,6 +216,17 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 	public void getObsByPatientConceptEncounter_shouldIncludeArchivedObs() throws Exception {
 		DWRObsService dwrService = new DWRObsService();
 		
+		// Create and explicitly void a regular (live) observation to test includeVoidedObs=true
+		org.openmrs.api.ObsService obsService = Context.getObsService();
+		Obs liveObs = new Obs();
+		liveObs.setPerson(Context.getPersonService().getPerson(2));
+		liveObs.setConcept(Context.getConceptService().getConcept(21));
+		liveObs.setObsDatetime(new java.util.Date());
+		liveObs.setValueCoded(Context.getConceptService().getConcept(3)); // required for concept 21
+		obsService.saveObs(liveObs, "saving");
+		obsService.voidObs(liveObs, "testing");
+		Integer liveObsId = liveObs.getObsId();
+		
 		try {
 			Context.getAdministrationService().executeSQL(
 				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2026-01-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
@@ -224,14 +235,20 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 			Vector<ObsListItem> items = dwrService.getObsByPatientConceptEncounter("2", "21", null);
 			
 			boolean foundArchived = false;
+			boolean foundLiveVoided = false;
 			for (ObsListItem obsItem : items) {
 				if (obsItem.getObsId().equals(999)) {
 					foundArchived = true;
 					assertTrue(obsItem.getVoided());
 				}
+				if (obsItem.getObsId().equals(liveObsId)) {
+					foundLiveVoided = true;
+					assertTrue(obsItem.getVoided());
+				}
 			}
 			
-			assertTrue(foundArchived);
+			assertTrue(foundArchived, "Archived obs should be included");
+			assertTrue(foundLiveVoided, "Live but voided obs should be included");
 		} finally {
 			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 999;", false);
 		}

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -221,7 +221,7 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 		Obs liveObs = new Obs();
 		liveObs.setPerson(Context.getPersonService().getPerson(2));
 		liveObs.setConcept(Context.getConceptService().getConcept(21));
-		liveObs.setObsDatetime(new java.util.Date());
+		liveObs.setObsDatetime(new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2008-08-01"));
 		liveObs.setValueCoded(Context.getConceptService().getConcept(3)); // required for concept 21
 		obsService.saveObs(liveObs, "saving");
 		obsService.voidObs(liveObs, "testing");
@@ -229,8 +229,7 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 		
 		try {
 			Context.getAdministrationService().executeSQL(
-				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2027-01-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
-			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
+				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2008-09-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
 			
 			Vector<ObsListItem> items = dwrService.getObsByPatientConceptEncounter("2", "21", null);
 			

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -236,19 +236,25 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 			
 			boolean foundArchived = false;
 			boolean foundLiveVoided = false;
-			for (ObsListItem obsItem : items) {
+			int archivedIndex = -1;
+			int liveIndex = -1;
+			for (int i = 0; i < items.size(); i++) {
+				ObsListItem obsItem = items.get(i);
 				if (obsItem.getObsId().equals(999)) {
 					foundArchived = true;
+					archivedIndex = i;
 					assertTrue(obsItem.getVoided());
 				}
 				if (obsItem.getObsId().equals(liveObsId)) {
 					foundLiveVoided = true;
+					liveIndex = i;
 					assertTrue(obsItem.getVoided());
 				}
 			}
 			
 			assertTrue(foundArchived, "Archived obs should be included");
 			assertTrue(foundLiveVoided, "Live but voided obs should be included");
+			assertTrue(liveIndex < archivedIndex, "Live obs should come before archived obs");
 		} finally {
 			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 999;", false);
 		}

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRObservationServiceTest.java
@@ -229,7 +229,7 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 		
 		try {
 			Context.getAdministrationService().executeSQL(
-				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2026-01-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
+				"INSERT INTO obs_archive (obs_id, person_id, concept_id, obs_datetime, voided, uuid, creator, date_created, status) VALUES (999, 2, 21, '2027-01-01', 1, 'archive-uuid-1', 1, '2026-01-01', 'FINAL')", false);
 			Context.getAdministrationService().setGlobalProperty("obs.archive.last_processed_obs_id", "999");
 			
 			Vector<ObsListItem> items = dwrService.getObsByPatientConceptEncounter("2", "21", null);
@@ -254,7 +254,7 @@ public class DWRObservationServiceTest extends BaseModuleWebContextSensitiveTest
 			
 			assertTrue(foundArchived, "Archived obs should be included");
 			assertTrue(foundLiveVoided, "Live but voided obs should be included");
-			assertTrue(liveIndex < archivedIndex, "Live obs should come before archived obs");
+			assertTrue(archivedIndex < liveIndex, "Newer archived obs should sort ahead of the older live obs");
 		} finally {
 			Context.getAdministrationService().executeSQL("DELETE FROM obs_archive WHERE obs_id = 999;", false);
 		}


### PR DESCRIPTION
## Description of what I changed
This PR updates the Legacy UI to properly fetch and display archived observations, ensuring they are not lost to the user after being archived - implemented as part of https://openmrs.atlassian.net/browse/TRUNK-6648.

## Specific changes include

- `DWRObsService.java`: Merged archived observations into the search results so they can be viewed and managed on the "Manage Observations" page.
- `EncounterFormController.java`: Switched to `getAllObsIncludingArchived()` to ensure archived observations are passed to the view, restoring the functionality of the "Toggle Voided" button on the Encounter form.
- `obs.js`: Updated the DWR rowCreator to correctly apply the .voided CSS class so that voided observations dynamically render with the standard OpenMRS strikethrough styling while preserving alternating row colors.

## Issue I worked on
see https://openmrs.atlassian.net/browse/LUI-213