### PR TITLE
L UI-214

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,14 +2,30 @@ name: Build with Maven
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 2.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ 2.x ]
   workflow_dispatch:
 
 jobs:
   build:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
     with:
-      java_versions: '[8, 11, 17, 21, 25]'
+      java_versions: '["8", "11", "17", "21"]'
       main_java_version: '8'
+      maven_args: 'clean install -Dmaven.javadoc.skip=true'
+      deploy_branch: '2.x'
+      run_owasp_check: false
+    secrets:
+      MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+      MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}
+
+  owasp-dependency-check:
+    if: ${{ github.event_name != 'pull_request' }}
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/owasp-dependency-check.yml@main
+    with:
+      java_version: '8'
+    secrets:
+      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,22 +10,6 @@ on:
 jobs:
   build:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
-    with:
-      java_versions: '["8", "11", "17", "21"]'
-      main_java_version: '8'
-      maven_args: 'clean install -Dmaven.javadoc.skip=true'
-      deploy_branch: '2.x'
-      run_owasp_check: false
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}
-
-  owasp-dependency-check:
-    if: ${{ github.event_name != 'pull_request' }}
-    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/owasp-dependency-check.yml@main
-    with:
-      java_version: '8'
-    secrets:
-      NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-      BOT_GH_TOKEN: ${{ secrets.OMRS_BOT_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
-      BOT_PAT: ${{ secrets.BOT_PAT }}
+      BOT_PAT: ${{ secrets.OMRS_BOT_GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,30 @@
-on:
-  push:
-    tags:
-      - '*' # Create release for every new tag
+name: Release
 
-name: Create Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g., 2.1.0)'
+        required: true
+      development_version:
+        description: 'Next development version (e.g., 2.2.0-SNAPSHOT)'
+        required: true
+      branch:
+        description: 'Branch to release from (e.g., master)'
+        required: false
+        default: '2.x'
 
 jobs:
-  build:
-    name: Create Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Create Release Notes
-        uses: openmrs/openmrs-contrib-create-release-notes@v1.0.3
-        id: create-release-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with: 
-          head-ref: ${{ github.ref }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          body: |
-            ## What's Changed
-            ${{ steps.create-release-notes.outputs.release-notes }}
-          draft: false
-          prerelease: false
+  release:
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/release-backend-module.yml@main
+    permissions:
+      contents: write
+    with:
+      release_version: ${{ inputs.release_version }}
+      development_version: ${{ inputs.development_version }}
+      branch: ${{ inputs.branch }}
+      java_version: '8'
+    secrets:
+      MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
+      MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}
+      BOT_PAT: ${{ secrets.BOT_PAT }}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.1.0</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>legacyui-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0</version>
 	</parent>
 
 	<artifactId>legacyui-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0</version>
 	</parent>
 
 	<artifactId>legacyui-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.2.0</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>legacyui-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/legacyui/GeneralUtils.java
+++ b/api/src/main/java/org/openmrs/module/legacyui/GeneralUtils.java
@@ -22,14 +22,15 @@ public class GeneralUtils {
 	/**
 	 * Get the concept by id, the id can either be 1)an integer id like 5090 or 2)mapping type id
 	 * like "XYZ:HT" or 3)uuid like "a3e12268-74bf-11df-9768-17cfc9833272"
+	 * <p>
+	 * <b>Should</b> find a concept by its conceptId.<br>
+	 * <b>Should</b> find a concept by its mapping.<br>
+	 * <b>Should</b> find a concept by its uuid.<br>
+	 * <b>Should</b> return null otherwise.<br>
+	 * <b>Should</b> find a concept by its mapping with a space in between.
 	 * 
-	 * @param id
+	 * @param id the conceptId, mapping, or uuid identifying the concept
 	 * @return the concept if exist, else null
-	 * @should find a concept by its conceptId
-	 * @should find a concept by its mapping
-	 * @should find a concept by its uuid
-	 * @should return null otherwise
-	 * @should find a concept by its mapping with a space in between
 	 */
 	public static Concept getConcept(String id) {
 		Concept cpt = null;

--- a/api/src/main/java/org/openmrs/module/legacyui/api/LegacyUIService.java
+++ b/api/src/main/java/org/openmrs/module/legacyui/api/LegacyUIService.java
@@ -26,6 +26,16 @@ import org.openmrs.util.PrivilegeConstants;
 public interface LegacyUIService extends OpenmrsService {
 	
 	/**
+	 * Records that a patient has exited care.
+	 * <p>
+	 * <b>Should</b> save reason for exit observation for given patient.<br>
+	 * <b>Should</b> set death date and cause when given reason for exit equals death.<br>
+	 * <b>Should</b> terminate all program workflows associated with given patient.<br>
+	 * <b>Should</b> throw error when given patient is null.<br>
+	 * <b>Should</b> throw error when given date exited is null.<br>
+	 * <b>Should</b> throw error when given reason for exist is null.<br>
+	 * <b>Should</b> be tested more thoroughly.
+	 * 
 	 * @deprecated as of 1.10 and moved to exit from care module. This method is no longer supported
 	 *             because previously the patient's active orders would get discontinued in the
 	 *             process which is no longer happening
@@ -33,38 +43,37 @@ public interface LegacyUIService extends OpenmrsService {
 	 * @param dateExited - the declared date/time of the patient's exit
 	 * @param reasonForExit - the concept that corresponds with why the patient has been declared as
 	 *            exited
-	 * @throws APIException
-	 * @should save reason for exit observation for given patient
-	 * @should set death date and cause when given reason for exit equals death
-	 * @should terminate all program workflows associated with given patient
-	 * @should throw error when given patient is null
-	 * @should throw error when given date exited is null
-	 * @should throw error when given reason for exist is null
-	 * @should be tested more thoroughly
+	 * @throws APIException if any input parameter is invalid
 	 */
 	@Deprecated
 	@Authorized({ PrivilegeConstants.EDIT_PATIENTS })
 	public void exitFromCare(Patient patient, Date dateExited, Concept reasonForExit) throws APIException;
 	
 	/**
+	 * Triggers a ConceptStateConversion for the given patient.
+	 * <p>
+	 * <b>Should</b> trigger state conversion successfully.<br>
+	 * <b>Should</b> fail if patient is invalid.<br>
+	 * <b>Should</b> fail if trigger is invalid.<br>
+	 * <b>Should</b> fail if date converted is invalid.<br>
+	 * <b>Should</b> skip past patient programs that are already completed.
+	 * 
 	 * @deprecated as of 1.10, because the only place in core where it was called was
 	 *             PatientService#exitFromCare(Patient patient, Date dateExited, Concept
 	 *             reasonForExit) which was moved to exit from care module
 	 * @param patient - the Patient to trigger the ConceptStateConversion on
 	 * @param reasonForExit - the Concept to trigger the ConceptStateConversion
 	 * @param dateConverted - the Date of the ConceptStateConversion
-	 * @throws APIException
-	 * @should trigger state conversion successfully
-	 * @should fail if patient is invalid
-	 * @should fail if trigger is invalid
-	 * @should fail if date converted is invalid
-	 * @should skip past patient programs that are already completed
+	 * @throws APIException if any input parameter is invalid
 	 */
 	@Deprecated
 	public void triggerStateConversion(Patient patient, Concept reasonForExit, Date dateConverted) throws APIException;
 	
 	/**
-	 * @see OrderExtensionService#getProviderForUser(User)
+	 * Returns the first active {@link Provider} account associated with the given user.
+	 * 
+	 * @param user the user whose provider account to look up
+	 * @return the provider associated with the given user
 	 */
 	public Provider getProviderForUser(User user);
 }

--- a/api/src/main/java/org/openmrs/module/legacyui/api/impl/LegacyUIImpl.java
+++ b/api/src/main/java/org/openmrs/module/legacyui/api/impl/LegacyUIImpl.java
@@ -62,7 +62,7 @@ public class LegacyUIImpl extends BaseOpenmrsService implements LegacyUIService 
 	 * @param dateExited - the declared date/time of the patient's exit
 	 * @param reasonForExit - the concept that corresponds with why the patient has been declared as
 	 *            exited
-	 * @throws APIException
+	 * @throws APIException if any input parameter is invalid
 	 */
 	public void exitFromCare(Patient patient, Date dateExited, Concept reasonForExit) throws APIException {
 		
@@ -167,9 +167,6 @@ public class LegacyUIImpl extends BaseOpenmrsService implements LegacyUIService 
 	 * Copied from OpenMRS core 1.12.1 See
 	 * https://github.com/openmrs/openmrs-core/blob/1.12.1/api/src
 	 * /main/java/org/openmrs/api/impl/ProgramWorkflowServiceImpl.java#L450
-	 * 
-	 * @see org.openmrs.api.ProgramWorkflowService#triggerStateConversion(org.openmrs.Patient,
-	 *      org.openmrs.Concept, java.util.Date)
 	 */
 	public void triggerStateConversion(Patient patient, Concept trigger, Date dateConverted) {
 		
@@ -221,7 +218,10 @@ public class LegacyUIImpl extends BaseOpenmrsService implements LegacyUIService 
 	}
 	
 	/**
-	 * @see OrderExtensionService#getProviderForUser(User)
+	 * Returns the first active {@link Provider} account associated with the given user.
+	 * 
+	 * @param user the user whose provider account to look up
+	 * @return the provider associated with the given user
 	 */
 	@Transactional(readOnly = true)
 	public Provider getProviderForUser(User user) {
@@ -238,15 +238,15 @@ public class LegacyUIImpl extends BaseOpenmrsService implements LegacyUIService 
 	 * https://github.com/openmrs/openmrs-core/blob/1.9.13/api/src
 	 * /main/java/org/openmrs/order/OrderUtil.java#L52 Discontinues all current orders for the given
 	 * <code>patient</code>
+	 * <p>
+	 * <b>Should</b> discontinue all orders for the given patient if none are yet discontinued.<br>
+	 * <b>Should</b> not affect orders that were already discontinued on the specified date.<br>
+	 * <b>Should</b> not affect orders that end before the specified date.<br>
+	 * <b>Should</b> not affect orders that start after the specified date.
 	 * 
-	 * @param patient
-	 * @param discontinueReason
-	 * @param discontinueDate
-	 * @see OrderService#discontinueOrder(org.openmrs.Order, Concept, Date)
-	 * @should discontinue all orders for the given patient if none are yet discontinued
-	 * @should not affect orders that were already discontinued on the specified date
-	 * @should not affect orders that end before the specified date
-	 * @should not affect orders that start after the specified date
+	 * @param patient the patient whose orders to discontinue
+	 * @param discontinueReason the concept describing why the orders are being discontinued
+	 * @param discontinueDate the date on which to discontinue the orders
 	 */
 	public void discontinueAllDrugOrders(Patient patient, Concept discontinueReason, Date discontinueDate) {
 		if (log.isDebugEnabled())

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.1.0</version>
+		<version>2.2.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>legacyui-omod</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0</version>
 	</parent>
 
 	<artifactId>legacyui-omod</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0</version>
 	</parent>
 
 	<artifactId>legacyui-omod</artifactId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>legacyui</artifactId>
-		<version>2.2.0</version>
+		<version>2.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>legacyui-omod</artifactId>

--- a/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InArchiveListController.java
+++ b/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InArchiveListController.java
@@ -25,12 +25,15 @@ import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * controller for the HL7 archives list view; only displays HL7s that have not been migrated to the
  * filesystem
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_HL7_IN_ARCHIVE)
 public class Hl7InArchiveListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InArchiveMigrationController.java
+++ b/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InArchiveMigrationController.java
@@ -15,11 +15,14 @@ import org.openmrs.hl7.Hl7InArchivesMigrateThread;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Processes requests for the page for managing the hl7InArchive migration
  */
 @Controller
+@RequirePrivilege(value = { PrivilegeConstants.GET_HL7_IN_ARCHIVE,PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE,PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE }, requireAll = true)
 public class Hl7InArchiveMigrationController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InErrorListController.java
+++ b/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InErrorListController.java
@@ -28,8 +28,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_HL7_IN_EXCEPTION)
 public class Hl7InErrorListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InQueueListController.java
+++ b/omod/src/main/java/org/openmrs/hl7/web/controller/Hl7InQueueListController.java
@@ -29,8 +29,11 @@ import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_HL7_IN_QUEUE)
 public class Hl7InQueueListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/module/web/controller/ModuleListController.java
+++ b/omod/src/main/java/org/openmrs/module/web/controller/ModuleListController.java
@@ -52,11 +52,13 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Controller that backs the /admin/modules/modules.list page. This controller makes a list of
  * modules available and lets the user start, stop, and unload modules one at a time.
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_MODULES)
 public class ModuleListController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/module/web/controller/ModuleListController.java
+++ b/omod/src/main/java/org/openmrs/module/web/controller/ModuleListController.java
@@ -305,10 +305,12 @@ public class ModuleListController extends SimpleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> sort modules correctly.
+	 * 
 	 * @param modulesToStart
 	 * @return a new list, with the same elements as modulesToStart, sorted so that no module is
 	 *         before a module it depends on
-	 * @should sort modules correctly
 	 */
 	List<Module> sortStartupOrder(List<Module> modulesToStart) {
 		// can't use Collections.sort--we need a slower algorithm that guarantees to compare every pair of elements

--- a/omod/src/main/java/org/openmrs/module/web/controller/ModuleManagementController.java
+++ b/omod/src/main/java/org/openmrs/module/web/controller/ModuleManagementController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller which allows users to identify dependencies between modules for shutdown/restart
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
  */
 @Controller
 @RequestMapping(value = "/admin/modules/manage/")
+@RequirePrivilege(PrivilegeConstants.MANAGE_MODULES)
 public class ModuleManagementController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/module/web/controller/ModulePropertiesFormController.java
+++ b/omod/src/main/java/org/openmrs/module/web/controller/ModulePropertiesFormController.java
@@ -30,7 +30,9 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_MODULES)
 public class ModulePropertiesFormController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/module/web/extension/ExtensionUtil.java
+++ b/omod/src/main/java/org/openmrs/module/web/extension/ExtensionUtil.java
@@ -31,10 +31,11 @@ public class ExtensionUtil {
 	/**
 	 * Searches for all modules implementing {@link AddEncounterToVisitExtension} and returns the
 	 * set of links.
+	 * <p>
+	 * <b>Should</b> return empty set if there is no AddEncounterToVisitExtension.<br>
+	 * <b>Should</b> return links if there are AddEncounterToVisitExtensions.
 	 * 
 	 * @return the set of Links
-	 * @should return empty set if there is no AddEncounterToVisitExtension
-	 * @should return links if there are AddEncounterToVisitExtensions
 	 */
 	public static Set<Link> getAllAddEncounterToVisitLinks() {
 		List<Extension> extensions = ModuleFactory

--- a/omod/src/main/java/org/openmrs/notification/web/controller/AlertFormController.java
+++ b/omod/src/main/java/org/openmrs/notification/web/controller/AlertFormController.java
@@ -40,7 +40,9 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ALERTS)
 public class AlertFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/notification/web/controller/AlertListController.java
+++ b/omod/src/main/java/org/openmrs/notification/web/controller/AlertListController.java
@@ -34,7 +34,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ALERTS)
 public class AlertListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/notification/web/dwr/DWRAlertService.java
+++ b/omod/src/main/java/org/openmrs/notification/web/dwr/DWRAlertService.java
@@ -22,6 +22,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.notification.Alert;
 import org.openmrs.notification.AlertService;
 import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 public class DWRAlertService {
 	
@@ -33,6 +34,7 @@ public class DWRAlertService {
 	 * 
 	 * @return list of alerts
 	 */
+	@RequirePrivilege
 	public List<AlertListItem> getAlerts() {
 		
 		// The list of AlertListItems that we will return
@@ -59,6 +61,7 @@ public class DWRAlertService {
 	 * 
 	 * @param alertId
 	 */
+	@RequirePrivilege
 	public void markAlertRead(Integer alertId) {
 		
 		try {
@@ -94,35 +97,35 @@ public class DWRAlertService {
 	 * @param text the string to set as the alert text
 	 * @return true if the alert was successfully created and saved otherwise false
 	 */
+	@RequirePrivilege(PrivilegeConstants.MANAGE_ALERTS)
 	public boolean createAlert(String text) {
 		if (StringUtils.isNotBlank(text)) {
 			try {
-				Context.addProxyPrivilege(PrivilegeConstants.MANAGE_ALERTS);
 				Context.addProxyPrivilege(PrivilegeConstants.GET_USERS);
 				Context.addProxyPrivilege(PrivilegeConstants.GET_ROLES);
-				
+
 				Role role = Context.getUserService().getRole("System Developer");
 				Collection<User> users = Context.getUserService().getUsersByRole(role);
 				Context.getAlertService().saveAlert(new Alert(text, users));
-				
+
 				return true;
 			}
 			catch (Exception e) {
 				log.error("Error while creating an alert ", e);
 			}
 			finally {
-				Context.removeProxyPrivilege(PrivilegeConstants.MANAGE_ALERTS);
 				Context.removeProxyPrivilege(PrivilegeConstants.GET_USERS);
 				Context.removeProxyPrivilege(PrivilegeConstants.GET_ROLES);
 			}
 		}
-		
+
 		return false;
 	}
 	
 	/**
 	 * Marks all alert as read
 	 */
+	@RequirePrivilege
 	public void markAllAlertsRead() {
 		AlertService as = Context.getAlertService();
 		// Get the alert objects

--- a/omod/src/main/java/org/openmrs/notification/web/dwr/DWRMessageService.java
+++ b/omod/src/main/java/org/openmrs/notification/web/dwr/DWRMessageService.java
@@ -20,45 +20,42 @@ import org.openmrs.contrib.dwr.WebContextFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.notification.MessageService;
 import org.openmrs.notification.NotificationConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 public class DWRMessageService {
 	
 	protected final Log log = LogFactory.getLog(getClass());
 	
+	@RequirePrivilege
 	public boolean sendFeedback(String sender, String subject, String content) {
-		
+
 		HttpServletRequest request = WebContextFactory.get().getHttpServletRequest();
-		
-		if (!Context.isAuthenticated()) {
-			try {
-				MessageService messageService = Context.getMessageService();
-				
-				String recipients = NotificationConstants.FEEDBACK_EMAIL_ADDRESS;
-				if (StringUtils.isEmpty(subject)) {
-					subject = NotificationConstants.FEEDBACK_EMAIL_SUBJECT;
-				}
-				
-				String referer = request.getPathTranslated();
-				String userName = "an Anonymous User";
-				if (Context.isAuthenticated()) {
-					userName = Context.getAuthenticatedUser().getPersonName().getFullName();
-				}
-				
-				content += "\n\n This email sent from: " + referer + " by: " + userName;
-				
-				messageService.sendMessage(recipients, sender, subject, content);
-				
-				return true;
-				
+
+		try {
+			MessageService messageService = Context.getMessageService();
+
+			String recipients = NotificationConstants.FEEDBACK_EMAIL_ADDRESS;
+			if (StringUtils.isEmpty(subject)) {
+				subject = NotificationConstants.FEEDBACK_EMAIL_SUBJECT;
 			}
-			catch (Exception e) {
-				log.error("Error sending feedback", e);
-			}
+
+			String referer = request.getPathTranslated();
+			String userName = Context.getAuthenticatedUser().getPersonName().getFullName();
+
+			content += "\n\n This email sent from: " + referer + " by: " + userName;
+
+			messageService.sendMessage(recipients, sender, subject, content);
+
+			return true;
 		}
-		
+		catch (Exception e) {
+			log.error("Error sending feedback", e);
+		}
+
 		return false;
 	}
 	
+	@RequirePrivilege
 	public Vector<Object> sendMessage(String recipients, String sender, String subject, String content) {
 		
 		// List to return

--- a/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerFormController.java
+++ b/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerFormController.java
@@ -66,10 +66,12 @@ public class SchedulerFormController extends SimpleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> not throw null pointer exception if repeat interval is null.
+	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#processFormSubmission(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should not throw null pointer exception if repeat interval is null
 	 */
 	@Override
 	protected ModelAndView processFormSubmission(HttpServletRequest request, HttpServletResponse response, Object command,
@@ -116,14 +118,15 @@ public class SchedulerFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> reschedule a currently scheduled task.<br>
+	 * <b>Should</b> not reschedule a task that is not currently scheduled.<br>
+	 * <b>Should</b> not reschedule a task if the start time has passed.<br>
+	 * <b>Should</b> not reschedule an executing task.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should reschedule a currently scheduled task
-	 * @should not reschedule a task that is not currently scheduled
-	 * @should not reschedule a task if the start time has passed
-	 * @should not reschedule an executing task
 	 */
 	@Override
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object command,

--- a/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerFormController.java
+++ b/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerFormController.java
@@ -35,7 +35,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_SCHEDULER)
 public class SchedulerFormController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerListController.java
+++ b/omod/src/main/java/org/openmrs/scheduler/web/controller/SchedulerListController.java
@@ -34,7 +34,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_SCHEDULER)
 public class SchedulerListController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/OptionsForm.java
+++ b/omod/src/main/java/org/openmrs/web/OptionsForm.java
@@ -10,6 +10,7 @@
 package org.openmrs.web;
 
 import org.openmrs.PersonName;
+import org.openmrs.web.controller.OptionsFormController;
 
 /**
  * This is the model/backing object for the "My Profile" page. This lets logged in users set

--- a/omod/src/main/java/org/openmrs/web/attribute/WebAttributeUtil.java
+++ b/omod/src/main/java/org/openmrs/web/attribute/WebAttributeUtil.java
@@ -79,7 +79,7 @@ public class WebAttributeUtil {
 	private static Pattern betweenSquareBrackets = Pattern.compile("\\[(\\d*)\\]");
 	
 	/**
-	 * something[3] -> 3
+	 * something[3] -&gt; 3
 	 * 
 	 * @param input
 	 * @return

--- a/omod/src/main/java/org/openmrs/web/attribute/handler/BaseMetadataFieldGenDatatypeHandler.java
+++ b/omod/src/main/java/org/openmrs/web/attribute/handler/BaseMetadataFieldGenDatatypeHandler.java
@@ -19,9 +19,11 @@ import org.openmrs.customdatatype.datatype.BaseMetadataDatatype;
 public abstract class BaseMetadataFieldGenDatatypeHandler<DT extends BaseMetadataDatatype<T>, T extends OpenmrsMetadata> extends SerializingFieldGenDatatypeHandler<DT, T> {
 	
 	/**
+	 * <p>
+	 * <b>Should</b> return the name.
+	 * 
 	 * @see SerializingFieldGenDatatypeHandler#toHtml(org.openmrs.customdatatype.CustomDatatype,
 	 *      String)
-	 * @should return the name
 	 */
 	@Override
 	public String toHtml(CustomDatatype<T> datatype, String valueReference) {
@@ -29,9 +31,11 @@ public abstract class BaseMetadataFieldGenDatatypeHandler<DT extends BaseMetadat
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> use the name in the html summary instance.
+	 * 
 	 * @see SerializingFieldGenDatatypeHandler#toHtmlSummary(org.openmrs.customdatatype.CustomDatatype,
 	 *      String)
-	 * @should use the name in the html summary instance
 	 */
 	@Override
 	public CustomDatatype.Summary toHtmlSummary(CustomDatatype<T> datatype, String valueReference) {

--- a/omod/src/main/java/org/openmrs/web/attribute/handler/SerializingFieldGenDatatypeHandler.java
+++ b/omod/src/main/java/org/openmrs/web/attribute/handler/SerializingFieldGenDatatypeHandler.java
@@ -34,9 +34,11 @@ import org.openmrs.propertyeditor.ProviderEditor;
 public abstract class SerializingFieldGenDatatypeHandler<DT extends SerializingCustomDatatype<T>, T> implements FieldGenDatatypeHandler<DT, T> {
 	
 	/**
+	 * <p>
+	 * <b>Should</b> return the correct typed value.
+	 * 
 	 * @see org.openmrs.web.attribute.handler.FieldGenDatatypeHandler#getValue(org.openmrs.customdatatype.CustomDatatype,
 	 *      javax.servlet.http.HttpServletRequest, java.lang.String)
-	 * @should return the correct typed value
 	 */
 	@Override
 	public T getValue(DT datatype, HttpServletRequest request, String formFieldName) throws InvalidCustomValueException {

--- a/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
@@ -170,21 +170,22 @@ public class ConceptFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> display numeric values from table.<br>
+	 * <b>Should</b> copy numeric values into numeric concepts.<br>
+	 * <b>Should</b> return a concept with a null id if no match is found.<br>
+	 * <b>Should</b> void a synonym marked as preferred when it is removed.<br>
+	 * <b>Should</b> set the local preferred name.<br>
+	 * <b>Should</b> add a new Concept map to an existing concept.<br>
+	 * <b>Should</b> remove a concept map from an existing concept.<br>
+	 * <b>Should</b> ignore new concept map row if the user did not select a term.<br>
+	 * <b>Should</b> add a new Concept map when creating a concept.<br>
+	 * <b>Should</b> not save changes if there are validation errors.<br>
+	 * <b>Should</b> edit short name when there are multiple allowed locales.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should display numeric values from table
-	 * @should copy numeric values into numeric concepts
-	 * @should return a concept with a null id if no match is found
-	 * @should void a synonym marked as preferred when it is removed
-	 * @should set the local preferred name
-	 * @should add a new Concept map to an existing concept
-	 * @should remove a concept map from an existing concept
-	 * @should ignore new concept map row if the user did not select a term
-	 * @should add a new Concept map when creating a concept
-	 * @should not save changes if there are validation errors
-	 * @should edit short name when there are multiple allowed locales
 	 */
 	@Override
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
@@ -322,11 +323,13 @@ public class ConceptFormController extends SimpleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> add error if source is not saved.<br>
+	 * <b>Should</b> add error if map type is not saved.<br>
+	 * <b>Should</b> add error if term b is not saved.
+	 * 
 	 * @param concept
 	 * @param errors
-	 * @should add error if source is not saved
-	 * @should add error if map type is not saved
-	 * @should add error if term b is not saved
 	 */
 	void validateConceptUsesPersistedObjects(Concept concept, Errors errors) {
 		if (concept.getConceptMappings() != null) {
@@ -552,9 +555,10 @@ public class ConceptFormController extends SimpleFormController {
 		/**
 		 * This method takes all the form data from the input boxes and puts it onto the concept
 		 * object so that it can be saved to the database
+		 * <p>
+		 * <b>Should</b> set concept on concept answers.
 		 * 
 		 * @return the concept to be saved to the database
-		 * @should set concept on concept answers
 		 */
 		public Concept getConceptFromFormData() {
 			

--- a/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/ConceptFormController.java
@@ -88,6 +88,7 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This is the controlling class for the conceptForm.jsp page. It initBinder and formBackingObject
@@ -96,6 +97,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * 
  * @see org.openmrs.Concept
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPTS)
 public class ConceptFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/ConceptStatsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/ConceptStatsFormController.java
@@ -44,7 +44,10 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_OBS)
 public class ConceptStatsFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/GlobalPropertyPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/GlobalPropertyPortletController.java
@@ -33,9 +33,11 @@ import org.openmrs.util.PrivilegeConstants;
 public class GlobalPropertyPortletController extends PortletController {
 	
 	/**
+	 * <p>
+	 * <b>Should</b> exclude multiple prefixes.
+	 * 
 	 * @see org.openmrs.web.controller.PortletController#populateModel(javax.servlet.http.HttpServletRequest,
 	 *      java.util.Map)
-	 * @should exclude multiple prefixes
 	 */
 	@Override
 	protected void populateModel(HttpServletRequest request, Map<String, Object> model) {
@@ -87,10 +89,10 @@ public class GlobalPropertyPortletController extends PortletController {
 	 * Sets propertyPrefix to "${forModule}.", hidePrefix to "true" and excludePrefix to
 	 * excludePrefix + "${forModule}.started;${forModule}.mandatory" if forModule parameter is
 	 * present.
-	 * 
-	 * @should change model if forModule is present
-	 * @should not change mode if forModule is not present
-	 * @should not override excludePrefix but concatenate
+	 * <p>
+	 * <b>Should</b> change model if forModule is present.<br>
+	 * <b>Should</b> not change mode if forModule is not present.<br>
+	 * <b>Should</b> not override excludePrefix but concatenate.
 	 */
 	protected void setupModelForModule(Map<String, Object> model) {
 		if (Context.isAuthenticated()) {

--- a/omod/src/main/java/org/openmrs/web/controller/GlobalPropertyPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/GlobalPropertyPortletController.java
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Parameters to specify: * 'propertyPrefix' will limit to only global properties starting with that
@@ -27,6 +29,7 @@ import org.openmrs.api.context.Context;
  * 'title' will display that title * 'showHeader' whether or not to show a header row in the table
  * (default true) Values put in the model: * 'properties' -&gt; List&lt;GlobalProperty&gt;
  */
+@RequirePrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES)
 public class GlobalPropertyPortletController extends PortletController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
@@ -48,6 +48,7 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This is the controller for the "My Profile" page. This lets logged in users set personal
@@ -55,6 +56,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * 
  * @see OptionsForm
  */
+@RequirePrivilege
 public class OptionsFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/OptionsFormController.java
@@ -104,14 +104,15 @@ public class OptionsFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> accept 2 characters as username.<br>
+	 * <b>Should</b> accept email address as username if enabled.<br>
+	 * <b>Should</b> reject 1 character as username.<br>
+	 * <b>Should</b> reject invalid email address as username if enabled.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should accept 2 characters as username
-	 * @should accept email address as username if enabled
-	 * @should reject 1 character as username
-	 * @should reject invalid email address as username if enabled
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
 	        BindException errors) throws Exception {

--- a/omod/src/main/java/org/openmrs/web/controller/PatientEncountersPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PatientEncountersPortletController.java
@@ -14,11 +14,14 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.openmrs.api.context.Context;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for the patientEncounters portlet. Provides a map telling which forms have their view
  * and edit links overridden by form entry modules
  */
+@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 public class PatientEncountersPortletController extends PortletController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/PatientProgramsPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PatientProgramsPortletController.java
@@ -17,7 +17,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.openmrs.Location;
 import org.openmrs.Program;
 import org.openmrs.api.context.Context;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_PATIENT_PROGRAMS)
 public class PatientProgramsPortletController extends PortletController {
 	
 	protected void populateModel(HttpServletRequest request, Map<String, Object> model) {

--- a/omod/src/main/java/org/openmrs/web/controller/PatientVisitsPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PatientVisitsPortletController.java
@@ -20,11 +20,14 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Encounter;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for the patientEncounters portlet. Provides a map telling which forms have their view
  * and edit links overridden by form entry modules
  */
+@RequirePrivilege(PrivilegeConstants.GET_VISITS)
 public class PatientVisitsPortletController extends PortletController {
 	
 	private static final Log log = LogFactory.getLog(PatientVisitsPortletController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/PersonFormEntryPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PersonFormEntryPortletController.java
@@ -26,11 +26,14 @@ import org.openmrs.module.Extension.MEDIA_TYPE;
 import org.openmrs.module.web.FormEntryContext;
 import org.openmrs.module.web.extension.FormEntryHandler;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for the PersonFormEntry portlet Provides a map telling which url to hit to enter each
  * form
  */
+@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 public class PersonFormEntryPortletController extends PortletController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/PersonRelationshipsPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PersonRelationshipsPortletController.java
@@ -16,7 +16,10 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.openmrs.RelationshipType;
 import org.openmrs.api.context.Context;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_RELATIONSHIPS)
 public class PersonRelationshipsPortletController extends PortletController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/PortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/PortletController.java
@@ -91,9 +91,9 @@ public class PortletController implements Controller {
 	 *          (Map&lt;Integer, Concept&gt;) conceptMap
 	 *          (Map&lt;String, Concept&gt;) conceptMapByStringIds
 	 * </pre>
-	 * 
-	 * @should calculate bmi into patientBmiAsString
-	 * @should not fail with empty height and weight properties
+	 * <p>
+	 * <b>Should</b> calculate bmi into patientBmiAsString.<br>
+	 * <b>Should</b> not fail with empty height and weight properties.
 	 */
 	@SuppressWarnings("unchecked")
 	public ModelAndView handleRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException,

--- a/omod/src/main/java/org/openmrs/web/controller/RedirectController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/RedirectController.java
@@ -21,6 +21,7 @@ import org.springframework.web.servlet.mvc.Controller;
 /**
  * Redirects the request to the given <code>formView</code>
  */
+@SuppressWarnings("unused")
 public class RedirectController implements Controller {
 	
 	private String redirectView = "";

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptAttributeTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptAttributeTypeFormController.java
@@ -25,8 +25,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
 
 import java.util.Collection;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_ATTRIBUTE_TYPES)
 public class ConceptAttributeTypeFormController {
 	
 	private static final String CONCEPT_ATTRIBUTE_TYPES_LIST_URL = "redirect:/admin/concepts/conceptAttributeTypes.list";

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptAttributeTypeListController.java
@@ -13,6 +13,8 @@ import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing all concept attribute types.
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @since 2.0
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_ATTRIBUTE_TYPES)
 public class ConceptAttributeTypeListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptClassFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptClassFormController.java
@@ -26,7 +26,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_CLASSES)
 public class ConceptClassFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptClassListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptClassListController.java
@@ -32,7 +32,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_CLASSES)
 public class ConceptClassListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDatatypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDatatypeListController.java
@@ -31,7 +31,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_DATATYPES)
 public class ConceptDatatypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDrugFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDrugFormController.java
@@ -34,7 +34,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPTS)
 public class ConceptDrugFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDrugListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptDrugListController.java
@@ -21,7 +21,10 @@ import org.openmrs.Drug;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPTS)
 public class ConceptDrugListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptMapTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptMapTypeFormController.java
@@ -28,11 +28,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller class for processing requests for managing concept map types
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_MAP_TYPES)
 public class ConceptMapTypeFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalFormController.java
@@ -49,7 +49,9 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPTS)
 public class ConceptProposalFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalFormController.java
@@ -108,12 +108,13 @@ public class ConceptProposalFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> create a single unique synonym and obs for all similar proposals.<br>
+	 * <b>Should</b> work properly for country locales.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should create a single unique synonym and obs for all similar proposals
-	 * @should work properly for country locales
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
 	        BindException errors) throws Exception {

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptProposalListController.java
@@ -27,7 +27,10 @@ import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsConstants;
 import org.springframework.validation.Errors;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
 public class ConceptProposalListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptReferenceTermFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptReferenceTermFormController.java
@@ -33,11 +33,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller class for processing requests for managing Concept reference terms
  */
 @Controller
+@RequirePrivilege(value = { PrivilegeConstants.MANAGE_CONCEPT_REFERENCE_TERMS,PrivilegeConstants.GET_CONCEPT_MAP_TYPES }, requireAll = true)
 public class ConceptReferenceTermFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptSourceFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptSourceFormController.java
@@ -33,7 +33,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_SOURCES)
 public class ConceptSourceFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptSourceListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptSourceListController.java
@@ -29,7 +29,10 @@ import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_SOURCES)
 public class ConceptSourceListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordFormController.java
@@ -27,6 +27,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This is the controlling class for the conceptStopWordForm.jsp page. This class used to add a new
@@ -37,6 +39,7 @@ import org.springframework.web.servlet.mvc.SimpleFormController;
  */
 @Controller
 @RequestMapping(value = "admin/concepts/conceptStopWord.form")
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_STOP_WORDS)
 public class ConceptStopWordFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordFormController.java
@@ -49,14 +49,15 @@ public class ConceptStopWordFormController {
 	
 	/**
 	 * Handle the add new ConceptStopWord
+	 * <p>
+	 * <b>Should</b> add new ConceptStopWord.<br>
+	 * <b>Should</b> return error message if a duplicate ConceptStopWord is added.<br>
+	 * <b>Should</b> return error message for an empty ConceptStopWord.
 	 * 
 	 * @param httpSession
 	 * @param conceptStopWord
 	 * @param errors
 	 * @return path to forward to or an error message
-	 * @should add new ConceptStopWord
-	 * @should return error message if a duplicate ConceptStopWord is added
-	 * @should return error message for an empty ConceptStopWord
 	 */
 	@RequestMapping(method = RequestMethod.POST)
 	public String handleSubmission(HttpSession httpSession, @ModelAttribute("command") ConceptStopWord conceptStopWord,

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordListController.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This is the controlling class for the conceptStopWordList.jsp page. This class used to view the
@@ -32,6 +34,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  */
 @Controller
 @RequestMapping(value = "admin/concepts/conceptStopWord.list")
+@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_STOP_WORDS)
 public class ConceptStopWordListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ConceptStopWordListController.java
@@ -39,14 +39,15 @@ public class ConceptStopWordListController {
 	
 	/**
 	 * Handle the delete action
+	 * <p>
+	 * <b>Should</b> delete the given ConceptStopWord in the request parameter.<br>
+	 * <b>Should</b> add the success delete message in session attribute.<br>
+	 * <b>Should</b> add the already deleted error message in session attribute if delete the same
+	 * word twice.
 	 * 
 	 * @param session http session
 	 * @param conceptStopWordsToBeDeleted array of words to be deleted
 	 * @return ConceptStopWordList view
-	 * @should delete the given ConceptStopWord in the request parameter
-	 * @should add the success delete message in session attribute
-	 * @should add the already deleted error message in session attribute if delete the same word
-	 *         twice
 	 */
 	@RequestMapping(method = RequestMethod.POST)
 	public String handleSubmission(HttpSession session,
@@ -73,11 +74,12 @@ public class ConceptStopWordListController {
 	/**
 	 * This method to load all the Concept Stop Words in the request attribute and return the
 	 * ConceptStopWordList view
+	 * <p>
+	 * <b>Should</b> return Concept Stop Word List View.<br>
+	 * <b>Should</b> add all ConceptStopWords in session attribute.
 	 * 
 	 * @param session http session
 	 * @return ConceptStopWordList view
-	 * @should return Concept Stop Word List View
-	 * @should add all ConceptStopWords in session attribute
 	 */
 	@RequestMapping(method = RequestMethod.GET)
 	public String showForm(HttpSession session) {

--- a/omod/src/main/java/org/openmrs/web/controller/concept/ProposeConceptFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/concept/ProposeConceptFormController.java
@@ -35,7 +35,10 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.ADD_CONCEPT_PROPOSALS)
 public class ProposeConceptFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/customdatatype/CustomValueController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/customdatatype/CustomValueController.java
@@ -27,11 +27,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Controller for accessing custom datatype values
  */
 @Controller
+@RequirePrivilege
 public class CustomValueController {
 	
 	private final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/AddressTemplateController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/AddressTemplateController.java
@@ -25,12 +25,15 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.context.request.WebRequest;
 
 import java.util.List;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for managing {@link LocationTag}s
  */
 @Controller
 @SessionAttributes("addressTemplate")
+@RequirePrivilege(PrivilegeConstants.MANAGE_ADDRESS_TEMPLATES)
 public class AddressTemplateController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterDisplayController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterDisplayController.java
@@ -33,11 +33,14 @@ import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This is the java controller for the /openmrs/admin/encounters/encounterDisplay.list page. The jsp
  * for this display popup is located at /web/WEB-INF/view/encounters/encounterDisplay.jsp
  */
+@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 public class EncounterDisplayController implements Controller {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -64,11 +64,13 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This class controls the encounter.form jsp page. See
  * /web/WEB-INF/view/admin/encounters/encounterForm.jsp
  */
+@RequirePrivilege(PrivilegeConstants.EDIT_ENCOUNTERS)
 public class EncounterFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterFormController.java
@@ -171,11 +171,12 @@ public class EncounterFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> transfer encounter to another patient when encounter patient was changed.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should transfer encounter to another patient when encounter patient was changed
 	 */
 	@Override
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterIndexController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterIndexController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.encounter;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 public class EncounterIndexController {
 	
 	@RequestMapping(value = "admin/encounters/index")

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterRoleFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterRoleFormController.java
@@ -33,6 +33,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.springframework.util.StringUtils.hasText;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This class controls the encounter.form jsp page. See
@@ -40,6 +42,7 @@ import static org.springframework.util.StringUtils.hasText;
  */
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_ENCOUNTER_ROLES)
 public class EncounterRoleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterRoleFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterRoleFormController.java
@@ -55,13 +55,15 @@ public class EncounterRoleFormController {
 	public static final String ENCOUNTERS_PATH = "admin/encounters/";
 	
 	/**
+	 * <p>
+	 * <b>Should</b> save a new encounter role object.<br>
+	 * <b>Should</b> raise an error if validation of encounter role fails.<br>
+	 * <b>Should</b> edit and save an existing encounter.
+	 * 
 	 * @param session HttpSession for the user
 	 * @param encounterRole encounterRole object submitted from the form
 	 * @param errors list of errors if exists @return logical view name to resolve
 	 * @throws Exception
-	 * @should save a new encounter role object
-	 * @should raise an error if validation of encounter role fails
-	 * @should edit and save an existing encounter
 	 */
 	@RequestMapping(value = ENCOUNTERS_PATH + "encounterRole.form", method = RequestMethod.POST, params = "saveEncounterRole")
 	public String save(HttpSession session, @ModelAttribute("encounterRole") EncounterRole encounterRole,
@@ -78,12 +80,14 @@ public class EncounterRoleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> retire an existing encounter.<br>
+	 * <b>Should</b> raise an error if retire reason is not filled.
+	 * 
 	 * @param session HttpSession for the user
 	 * @param encounterRole encounterRole object submitted from the form
 	 * @param errors list of errors if exists @return logical view name to resolve
 	 * @throws Exception
-	 * @should retire an existing encounter
-	 * @should raise an error if retire reason is not filled
 	 */
 	@RequestMapping(value = ENCOUNTERS_PATH + "encounterRole.form", method = RequestMethod.POST, params = "retire")
 	public String retire(HttpSession session, @ModelAttribute("encounterRole") EncounterRole encounterRole,
@@ -103,11 +107,13 @@ public class EncounterRoleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> unretire an existing encounter.
+	 * 
 	 * @param session HttpSession for the user
 	 * @param encounterRole encounterRole object submitted from the form
 	 * @param errors list of errors if exists @return logical view name to resolve
 	 * @throws Exception
-	 * @should unretire an existing encounter
 	 */
 	@RequestMapping(value = ENCOUNTERS_PATH + "encounterRole.form", method = RequestMethod.POST, params = "unretire")
 	public String unretire(HttpSession session, @ModelAttribute("encounterRole") EncounterRole encounterRole,
@@ -123,13 +129,15 @@ public class EncounterRoleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> retire and unretire an existing encounter.<br>
+	 * <b>Should</b> raise an error if retire reason is not filled.<br>
+	 * <b>Should</b> purge an existing encounter.
+	 * 
 	 * @param session HttpSession for the user
 	 * @param encounterRole encounterRole object submitted from the form
 	 * @param errors list of errors if exists @return logical view name to resolve
 	 * @throws Exception
-	 * @should retire and unretire an existing encounter
-	 * @should raise an error if retire reason is not filled
-	 * @should purge an existing encounter
 	 */
 	@RequestMapping(value = ENCOUNTERS_PATH + "encounterRole.form", method = RequestMethod.POST, params = "purge")
 	public String purge(HttpSession session, @ModelAttribute("encounterRole") EncounterRole encounterRole,
@@ -160,9 +168,11 @@ public class EncounterRoleFormController {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> add list of encounter role objects to the model.
+	 * 
 	 * @param modelMap
 	 * @return logical view for the encounter list
-	 * @should add list of encounter role objects to the model
 	 */
 	@RequestMapping(value = ENCOUNTERS_PATH + "encounterRole.list", method = RequestMethod.GET)
 	public String getEncounterList(ModelMap modelMap) {

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterTypeFormController.java
@@ -38,7 +38,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ENCOUNTER_TYPES)
 public class EncounterTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/EncounterTypeListController.java
@@ -25,7 +25,10 @@ import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ENCOUNTER_TYPES)
 public class EncounterTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/HierarchyController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/HierarchyController.java
@@ -30,11 +30,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Shows the location hierarchy, in tree form
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATION_TAGS)
 public class HierarchyController {
 	
 	@RequestMapping("/admin/locations/hierarchy.list")

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/LocationFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/LocationFormController.java
@@ -39,7 +39,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATIONS)
 public class LocationFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/LocationFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/LocationFormController.java
@@ -78,12 +78,13 @@ public class LocationFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> retire location.<br>
+	 * <b>Should</b> not retire location if reason is empty.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should retire location
-	 * @should not retire location if reason is empty
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
 	        BindException errors) throws Exception {
@@ -143,9 +144,10 @@ public class LocationFormController extends SimpleFormController {
 	/**
 	 * This is called prior to displaying a form for the first time. It tells Spring the
 	 * form/command object to load into the request
+	 * <p>
+	 * <b>Should</b> return valid location given valid locationId.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.AbstractFormController#formBackingObject(javax.servlet.http.HttpServletRequest)
-	 * @should return valid location given valid locationId
 	 */
 	protected Object formBackingObject(HttpServletRequest request) throws ServletException {
 		

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/LocationListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/LocationListController.java
@@ -32,7 +32,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATIONS)
 public class LocationListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/encounter/LocationTagController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/encounter/LocationTagController.java
@@ -33,12 +33,15 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for managing {@link LocationTag}s
  */
 @Controller
 @SessionAttributes("locationTag")
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATION_TAGS)
 public class LocationTagController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/form/AuditFieldController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/AuditFieldController.java
@@ -22,12 +22,15 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller used to merge duplicate fields
  * <p>
  * This class calls the FormService's mergeDuplicateFields
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 public class AuditFieldController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FieldFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FieldFormController.java
@@ -39,7 +39,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 public class FieldFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FieldListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FieldListController.java
@@ -14,7 +14,10 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 public class FieldListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeFormController.java
@@ -24,7 +24,10 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_FIELD_TYPES)
 public class FieldTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeListController.java
@@ -29,7 +29,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Vector;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_FIELD_TYPES)
 public class FieldTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FieldTypeListController.java
@@ -41,11 +41,12 @@ public class FieldTypeListController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> display a user friendly error message.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should display a user friendly error message
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
 	        BindException errors) throws Exception {

--- a/omod/src/main/java/org/openmrs/web/controller/form/FormFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FormFormController.java
@@ -44,8 +44,11 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @SuppressWarnings("deprecation")
+@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 public class FormFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FormListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FormListController.java
@@ -29,7 +29,10 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 public class FormListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/form/FormResourceController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/form/FormResourceController.java
@@ -29,11 +29,14 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing resources on a form, and adding and deleting them
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 public class FormResourceController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/hl7/HL7SourceFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/hl7/HL7SourceFormController.java
@@ -20,7 +20,9 @@ import org.openmrs.hl7.HL7Source;
 import org.openmrs.api.APIException;
 import org.openmrs.hl7.HL7Service;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebConstants;
+import org.openmrs.web.security.RequirePrivilege;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.validation.BindException;
@@ -34,6 +36,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * called before page load. After submission,The onSubmit function receives the form/command object
  * that was modified by the input form and saves it to the db
  */
+@RequirePrivilege(PrivilegeConstants.PRIV_UPDATE_HL7_SOURCE)
 public class HL7SourceFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/hl7/Hl7SourceListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/hl7/Hl7SourceListController.java
@@ -23,11 +23,14 @@ import org.openmrs.hl7.HL7Source;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This is the controlling class for hl7SourceList.jsp page. It initBinder and formBackingObject are
  * called before page load
  */
+@RequirePrivilege(PrivilegeConstants.GET_HL7_SOURCE)
 public class Hl7SourceListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/layout/AddressLayoutPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/layout/AddressLayoutPortletController.java
@@ -13,7 +13,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.layout.LayoutSupport;
 import org.openmrs.layout.address.AddressSupport;
+import org.openmrs.web.security.RequirePrivilege;
 
+@RequirePrivilege
 public class AddressLayoutPortletController extends LayoutPortletController {
 	
 	private static Log log = LogFactory.getLog(AddressLayoutPortletController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/layout/NameLayoutPortletController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/layout/NameLayoutPortletController.java
@@ -13,7 +13,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.layout.LayoutSupport;
 import org.openmrs.layout.name.NameSupport;
+import org.openmrs.web.security.RequirePrivilege;
 
+@RequirePrivilege
 public class NameLayoutPortletController extends LayoutPortletController {
 	
 	private static final Log log = LogFactory.getLog(NameLayoutPortletController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/location/LocationAttributeTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/location/LocationAttributeTypeFormController.java
@@ -25,6 +25,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for creating/editing a location attribute type.
@@ -32,6 +34,7 @@ import org.springframework.web.context.request.WebRequest;
  * @since 1.9
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATION_ATTRIBUTE_TYPES)
 public class LocationAttributeTypeFormController {
 	
 	@ModelAttribute("datatypes")

--- a/omod/src/main/java/org/openmrs/web/controller/location/LocationAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/location/LocationAttributeTypeListController.java
@@ -13,6 +13,8 @@ import org.openmrs.api.context.Context;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing all location attribute types.
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
  * @since 1.9
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_LOCATION_ATTRIBUTE_TYPES)
 public class LocationAttributeTypeListController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/CurrentUsersController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/CurrentUsersController.java
@@ -21,6 +21,7 @@ import org.springframework.web.servlet.mvc.SimpleFormController;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Display the current users logged in the system.
@@ -29,6 +30,7 @@ import java.util.List;
  * @see LoginServlet
  * @see org.openmrs.web.SessionListener
  */
+@RequirePrivilege(PrivilegeConstants.VIEW_ADMIN_FUNCTIONS)
 public class CurrentUsersController extends SimpleFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/DatabaseChangesInfoController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/DatabaseChangesInfoController.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This backs the maintenance/databaseChangesInfo.jsp page that lists off all changes that have been
@@ -23,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @see DatabaseUpdater
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_DATABASE_CHANGES)
 public class DatabaseChangesInfoController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/GlobalPropertyController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/GlobalPropertyController.java
@@ -30,10 +30,13 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  *
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
 public class GlobalPropertyController extends SimpleFormController {
 	
 	public static final String PROP_NAME = "property";

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/GlobalPropertyController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/GlobalPropertyController.java
@@ -51,12 +51,13 @@ public class GlobalPropertyController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> save or update included properties.<br>
+	 * <b>Should</b> purge not included properties.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should save or update included properties
-	 * @should purge not included properties
 	 */
 	@SuppressWarnings("unchecked")
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/ImplementationIdFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/ImplementationIdFormController.java
@@ -23,11 +23,14 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This controller controls all uploading and syncing the Implementation Id with the implementation
  * id server
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_IMPLEMENTATION_ID)
 public class ImplementationIdFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/LocalesAndThemesFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/LocalesAndThemesFormController.java
@@ -20,12 +20,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Backs the localesAndThemes.jsp page to let the admin change the default locale, default theme,
  * etc
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
 public class LocalesAndThemesFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/QuickReportsController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/QuickReportsController.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Display the quick reports in the system.
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @see org.openmrs.web.SessionListener
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 public class QuickReportsController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/SearchIndexController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/SearchIndexController.java
@@ -21,11 +21,14 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * A controller for the search index
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_SEARCH_INDEX)
 public class SearchIndexController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/SearchIndexController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/SearchIndexController.java
@@ -36,7 +36,9 @@ public class SearchIndexController {
 	private Future<?> updateSearchIndexAsync = null;
 	
 	/**
-	 * @should return the search index view
+	 * <p>
+	 * <b>Should</b> return the search index view.
+	 * 
 	 * @return the searchIndex view
 	 */
 	@RequestMapping(method = RequestMethod.GET, value = "admin/maintenance/searchIndex.htm")
@@ -45,8 +47,10 @@ public class SearchIndexController {
 	}
 	
 	/**
-	 * @should return true for success if the update does not fail
-	 * @should return false for success if a RuntimeException is thrown
+	 * <p>
+	 * <b>Should</b> return true for success if the update does not fail.<br>
+	 * <b>Should</b> return false for success if a RuntimeException is thrown.
+	 * 
 	 * @return a marker indicating success
 	 */
 	@RequestMapping(method = RequestMethod.POST, value = "admin/maintenance/rebuildSearchIndex.htm")
@@ -70,9 +74,11 @@ public class SearchIndexController {
 	}
 	
 	/**
-	 * @should return return inProgress for status if a rebuildSearchIndex is not completed
-	 * @should return success for status if a rebuildSearchIndex is completed successfully
-	 * @should return error for status if a rebuildSearchIndex is not completed normally
+	 * <p>
+	 * <b>Should</b> return return inProgress for status if a rebuildSearchIndex is not completed.<br>
+	 * <b>Should</b> return success for status if a rebuildSearchIndex is completed successfully.<br>
+	 * <b>Should</b> return error for status if a rebuildSearchIndex is not completed normally.
+	 * 
 	 * @return hashMap of String, String holds a key named "status" indicating the status of rebuild
 	 *         search index
 	 */

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/ServerLogController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/ServerLogController.java
@@ -31,6 +31,8 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Get the log lines from the MEMORY_APPENDER appender of log4j as a String list and give it to the
@@ -38,6 +40,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * 
  * @see org.openmrs.util.MemoryAppender
  */
+@RequirePrivilege(PrivilegeConstants.VIEW_ADMIN_FUNCTIONS)
 public class ServerLogController extends SimpleFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/SettingsController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/SettingsController.java
@@ -36,11 +36,14 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Allows to manage settings.
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
 public class SettingsController {
 	
 	protected final Logger log = Logger.getLogger(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/SystemInformationController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/SystemInformationController.java
@@ -14,11 +14,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This backs the maintenance/systemInfo.jsp page that lists off all the system information.
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.VIEW_ADMIN_FUNCTIONS)
 public class SystemInformationController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/maintenance/SystemInformationController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/maintenance/SystemInformationController.java
@@ -32,13 +32,14 @@ public class SystemInformationController {
 	
 	/**
 	 * Called for GET requests only on the systemInfo page.
+	 * <p>
+	 * <b>Should</b> add openmrs information attribute to the model map.<br>
+	 * <b>Should</b> add java runtime information attribute to the model map.<br>
+	 * <b>Should</b> add database information attribute to the model map.<br>
+	 * <b>Should</b> add memory information attribute to the model map.<br>
+	 * <b>Should</b> add module information attribute to the model map.
 	 * 
 	 * @param model map
-	 * @should add openmrs information attribute to the model map
-	 * @should add java runtime information attribute to the model map
-	 * @should add database information attribute to the model map
-	 * @should add memory information attribute to the model map
-	 * @should add module information attribute to the model map
 	 */
 	@RequestMapping(method = RequestMethod.GET, value = "admin/maintenance/systemInfo.htm")
 	public String showPage(ModelMap model) {

--- a/omod/src/main/java/org/openmrs/web/controller/observation/ObsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/observation/ObsFormController.java
@@ -55,11 +55,14 @@ import org.springframework.web.multipart.MultipartHttpServletRequest;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This controller gives the backing object and does the saving for the obs.form page. The jsp for
  * this page is located in /web/WEB-INF/view/admin/observations/obsForm.jsp
  */
+@RequirePrivilege(PrivilegeConstants.EDIT_OBS)
 public class ObsFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/observation/ObsPageController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/observation/ObsPageController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.observation;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_OBS)
 public class ObsPageController {
 	
 	@RequestMapping("/admin/observations/index")

--- a/omod/src/main/java/org/openmrs/web/controller/observation/PersonObsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/observation/PersonObsFormController.java
@@ -24,11 +24,14 @@ import org.openmrs.api.ObsService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for the page that shows an administrator's view of all a patients observations
  * (possibly only for a specified concept)
  */
+@RequirePrivilege(PrivilegeConstants.EDIT_OBS)
 public class PersonObsFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/observation/handler/WebMediaHandler.java
+++ b/omod/src/main/java/org/openmrs/web/controller/observation/handler/WebMediaHandler.java
@@ -46,11 +46,11 @@ public class WebMediaHandler extends MediaHandler {
 	 * listed in ComplexObsHandler.*_VIEW. <br>
 	 * Currently the only implemented views are those implemented by ancestor plus the following:
 	 * <ul>
-	 * <li>{@link org.openmrs.web.WebConstants#HYPERLINK_VIEW}: a lightweight alternative to
-	 * returning the ComplexData from the parent class since this does not require access to the
-	 * service layer. Gives a link to the ComplexServlet for this obs
-	 * <li>{@link org.openmrs.web.WebConstants#HTML_VIEW}: An html tag that will display this
-	 * complex data. For this MediaHandler, its an html5 audio or video tag.
+	 * <li>{@code WebConstants.HYPERLINK_VIEW}: a lightweight alternative to returning the
+	 * ComplexData from the parent class since this does not require access to the service layer.
+	 * Gives a link to the ComplexServlet for this obs
+	 * <li>{@code WebConstants.HTML_VIEW}: An html tag that will display this complex data. For this
+	 * MediaHandler, its an html5 audio or video tag.
 	 * </ul>
 	 * 
 	 * @see org.openmrs.obs.handler.MediaHandler#getObs(org.openmrs.Obs, java.lang.String)

--- a/omod/src/main/java/org/openmrs/web/controller/observation/handler/WebMediaHandler.java
+++ b/omod/src/main/java/org/openmrs/web/controller/observation/handler/WebMediaHandler.java
@@ -31,6 +31,8 @@ public class WebMediaHandler extends MediaHandler {
 	
 	/** Views supported by this handler */
 	private static final String[] supportedViews = { ComplexObsHandler.URI_VIEW, ComplexObsHandler.HTML_VIEW, };
+
+	private String[] runtimeSupportedViews = null;
 	
 	/**
 	 * Default Constructor
@@ -89,11 +91,13 @@ public class WebMediaHandler extends MediaHandler {
 	 */
 	@Override
 	public String[] getSupportedViews() {
-		List view_list = new ArrayList(Arrays.asList(supportedViews));
-		view_list.addAll(Arrays.asList(super.getSupportedViews()));
-		String[] views = new String[view_list.size()];
-		view_list.toArray(views);
-		return views;
+		if (runtimeSupportedViews == null) {
+			String[] baseSupportedViews = super.getSupportedViews();
+			runtimeSupportedViews = new String[supportedViews.length + baseSupportedViews.length];
+			System.arraycopy(supportedViews, 0, runtimeSupportedViews, 0, supportedViews.length);
+			System.arraycopy(baseSupportedViews, 0, runtimeSupportedViews, supportedViews.length, baseSupportedViews.length);
+		}
+		return runtimeSupportedViews;
 	}
 	
 }

--- a/omod/src/main/java/org/openmrs/web/controller/patient/FindDuplicatePatientsController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/FindDuplicatePatientsController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.patient;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.EDIT_PATIENTS)
 public class FindDuplicatePatientsController {
 	
 	@RequestMapping(value = "admin/patients/findDuplicatePatients")

--- a/omod/src/main/java/org/openmrs/web/controller/patient/ManagePatientController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/ManagePatientController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.patient;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 public class ManagePatientController {
 	
 	@RequestMapping(value = "admin/patients/index")

--- a/omod/src/main/java/org/openmrs/web/controller/patient/MergePatientsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/MergePatientsFormController.java
@@ -41,7 +41,10 @@ import org.springframework.validation.ObjectError;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.EDIT_PATIENTS)
 public class MergePatientsFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
@@ -34,8 +34,11 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 public class PatientDashboardController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardController.java
@@ -46,11 +46,11 @@ public class PatientDashboardController {
 	
 	/**
 	 * render the patient dashboard model and direct to the view
-	 * 
-	 * @should render patient dashboard if given patient id is an existing id
-	 * @should render patient dashboard if given patient id is an existing uuid
-	 * @should redirect to find patient page if given patient id is not an existing id
-	 * @should redirect to find patient page if given patient id is not an existing uuid
+	 * <p>
+	 * <b>Should</b> render patient dashboard if given patient id is an existing id.<br>
+	 * <b>Should</b> render patient dashboard if given patient id is an existing uuid.<br>
+	 * <b>Should</b> redirect to find patient page if given patient id is not an existing id.<br>
+	 * <b>Should</b> redirect to find patient page if given patient id is not an existing uuid.
 	 */
 	@RequestMapping("/patientDashboard.form")
 	protected String renderDashboard(@RequestParam("patientId") String patientId, ModelMap map, HttpServletRequest request)
@@ -141,14 +141,15 @@ public class PatientDashboardController {
 	
 	/**
 	 * Get {@code Patient} by ID or UUID string.
+	 * <p>
+	 * <b>Should</b> return patient if given patient id is an existing id.<br>
+	 * <b>Should</b> return patient if given patient id is an existing uuid.<br>
+	 * <b>Should</b> return null if given null or whitespaces only.<br>
+	 * <b>Should</b> return null if given patient id is not an existing id.<br>
+	 * <b>Should</b> return null if given patient id is not an existing uuid.
 	 * 
 	 * @param patientId the id or uuid of wanted patient
 	 * @return patient matching given patient id
-	 * @should return patient if given patient id is an existing id
-	 * @should return patient if given patient id is an existing uuid
-	 * @should return null if given null or whitespaces only
-	 * @should return null if given patient id is not an existing id
-	 * @should return null if given patient id is not an existing uuid
 	 */
 	private Patient getPatient(String patientId) {
 		

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardGraphController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardGraphController.java
@@ -20,12 +20,15 @@ import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for returning flot aware JSON data
  */
 @Controller
 @RequestMapping(value = "/patientGraphJson.form")
+@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 public class PatientDashboardGraphController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardGraphController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientDashboardGraphController.java
@@ -33,13 +33,14 @@ public class PatientDashboardGraphController {
 	
 	/**
 	 * Method to formulate a JSON string used by flot for rendering the patient graph
+	 * <p>
+	 * <b>Should</b> return json data with observation details and critical values for the concept.<br>
+	 * <b>Should</b> return form for rendering the json data.
 	 * 
 	 * @param patientId identifier for the patient
 	 * @param conceptId identifier of the concept for which the graph has to be plotted
 	 * @param map
 	 * @return form which will render the JSON data
-	 * @should return json data with observation details and critical values for the concept
-	 * @should return form for rendering the json data
 	 */
 	@SuppressWarnings("unchecked")
 	@RequestMapping(method = RequestMethod.GET)

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
@@ -53,6 +53,7 @@ import org.openmrs.validator.PatientIdentifierValidator;
 import org.openmrs.validator.PatientValidator;
 import org.openmrs.web.WebConstants;
 import org.openmrs.web.controller.person.PersonFormController;
+import org.openmrs.web.security.RequirePrivilege;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.propertyeditors.CustomDateEditor;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
@@ -70,6 +71,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * 
  * @see org.openmrs.web.controller.person.PersonFormController
  */
+@RequirePrivilege(PrivilegeConstants.EDIT_PATIENTS)
 public class PatientFormController extends PersonFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientFormController.java
@@ -234,12 +234,13 @@ public class PatientFormController extends PersonFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> void patient when void reason is not empty.<br>
+	 * <b>Should</b> not void patient when void reason is empty.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should void patient when void reason is not empty
-	 * @should not void patient when void reason is empty
 	 */
 	@Override
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientIdentifierTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientIdentifierTypeFormController.java
@@ -36,7 +36,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_IDENTIFIER_TYPES)
 public class PatientIdentifierTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientIdentifierTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientIdentifierTypeListController.java
@@ -26,7 +26,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_IDENTIFIER_TYPES)
 public class PatientIdentifierTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/PatientListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/PatientListController.java
@@ -28,7 +28,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 public class PatientListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
@@ -51,6 +51,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This controller is used for the "mini"/"new"/"short" patient form. Only key/important attributes
@@ -60,6 +62,7 @@ import org.springframework.web.context.request.WebRequest;
  */
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.ADD_PATIENTS)
 public class ShortPatientFormController {
 	
 	private static final Log log = LogFactory.getLog(ShortPatientFormController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormController.java
@@ -177,6 +177,25 @@ public class ShortPatientFormController {
 	
 	/**
 	 * Handles the form submission by validating the form fields and saving it to the DB
+	 * <p>
+	 * <b>Should</b> pass if all the form data is valid.<br>
+	 * <b>Should</b> create a new patient.<br>
+	 * <b>Should</b> send the user back to the form in case of validation errors.<br>
+	 * <b>Should</b> void a name and replace it with a new one if it is changed to a unique value.<br>
+	 * <b>Should</b> void an address and replace it with a new one if it is changed to a unique
+	 * value.<br>
+	 * <b>Should</b> add a new name if the person had no names.<br>
+	 * <b>Should</b> add a new address if the person had none.<br>
+	 * <b>Should</b> ignore a new address that was added and voided at same time.<br>
+	 * <b>Should</b> set the cause of death as none a coded concept.<br>
+	 * <b>Should</b> set the cause of death as a none coded concept.<br>
+	 * <b>Should</b> void the cause of death obs that is none coded.<br>
+	 * <b>Should</b> add a new person attribute with a non empty value.<br>
+	 * <b>Should</b> not add a new person attribute with an empty value.<br>
+	 * <b>Should</b> void an existing person attribute with an empty value.<br>
+	 * <b>Should</b> should replace an existing attribute with a new one when edited.<br>
+	 * <b>Should</b> not void address if it was not changed.<br>
+	 * <b>Should</b> void address if it was changed.
 	 * 
 	 * @param request the webRequest object
 	 * @param relationshipsMap
@@ -184,23 +203,6 @@ public class ShortPatientFormController {
 	 *            fields
 	 * @param result
 	 * @return the view to forward to
-	 * @should pass if all the form data is valid
-	 * @should create a new patient
-	 * @should send the user back to the form in case of validation errors
-	 * @should void a name and replace it with a new one if it is changed to a unique value
-	 * @should void an address and replace it with a new one if it is changed to a unique value
-	 * @should add a new name if the person had no names
-	 * @should add a new address if the person had none
-	 * @should ignore a new address that was added and voided at same time
-	 * @should set the cause of death as none a coded concept
-	 * @should set the cause of death as a none coded concept
-	 * @should void the cause of death obs that is none coded
-	 * @should add a new person attribute with a non empty value
-	 * @should not add a new person attribute with an empty value
-	 * @should void an existing person attribute with an empty value
-	 * @should should replace an existing attribute with a new one when edited
-	 * @should not void address if it was not changed
-	 * @should void address if it was changed
 	 */
 	@RequestMapping(method = RequestMethod.POST, value = SHORT_PATIENT_FORM_URL)
 	public String saveShortPatient(WebRequest request, @ModelAttribute("personNameCache") PersonName personNameCache,

--- a/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormValidator.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/ShortPatientFormValidator.java
@@ -53,25 +53,26 @@ public class ShortPatientFormValidator implements Validator {
 	
 	/**
 	 * Validates the given Patient.
+	 * <p>
+	 * <b>Should</b> pass if the minimum required fields are provided and are valid.<br>
+	 * <b>Should</b> fail validation if gender is blank.<br>
+	 * <b>Should</b> fail validation if birthdate is blank.<br>
+	 * <b>Should</b> fail validation if birthdate makes patient 120 years old or older.<br>
+	 * <b>Should</b> fail validation if birthdate is a future date.<br>
+	 * <b>Should</b> fail validation if causeOfDeath is blank when patient is dead.<br>
+	 * <b>Should</b> fail if all name fields are empty or white space characters.<br>
+	 * <b>Should</b> fail if no identifiers are added.<br>
+	 * <b>Should</b> fail if all identifiers have been voided.<br>
+	 * <b>Should</b> fail if any name has more than 50 characters.<br>
+	 * <b>Should</b> fail validation if deathdate is a future date.<br>
+	 * <b>Should</b> fail if the deathdate is before the birthdate incase the patient is dead.<br>
+	 * <b>Should</b> reject a duplicate name.<br>
+	 * <b>Should</b> reject a duplicate address.
 	 * 
 	 * @param obj The patient to validate.
 	 * @param errors The patient to validate.
 	 * @see org.springframework.validation.Validator#validate(java.lang.Object,
 	 *      org.springframework.validation.Errors)
-	 * @should pass if the minimum required fields are provided and are valid
-	 * @should fail validation if gender is blank
-	 * @should fail validation if birthdate is blank
-	 * @should fail validation if birthdate makes patient 120 years old or older
-	 * @should fail validation if birthdate is a future date
-	 * @should fail validation if causeOfDeath is blank when patient is dead
-	 * @should fail if all name fields are empty or white space characters
-	 * @should fail if no identifiers are added
-	 * @should fail if all identifiers have been voided
-	 * @should fail if any name has more than 50 characters
-	 * @should fail validation if deathdate is a future date
-	 * @should fail if the deathdate is before the birthdate incase the patient is dead
-	 * @should reject a duplicate name
-	 * @should reject a duplicate address
 	 */
 	@Override
 	public void validate(Object obj, Errors errors) {

--- a/omod/src/main/java/org/openmrs/web/controller/patient/TribeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/patient/TribeFormController.java
@@ -13,11 +13,13 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This controller is left around only so that a message can be displayed where the old Manage Tribe
  * link was. This controller will be removed in the next version.
  */
+@RequirePrivilege("Manage Tribes")
 public class TribeFormController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/person/AddPersonController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/AddPersonController.java
@@ -35,7 +35,10 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.ADD_PERSONS)
 public class AddPersonController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/AddPersonController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/AddPersonController.java
@@ -123,10 +123,11 @@ public class AddPersonController extends SimpleFormController {
 	/**
 	 * This is called prior to displaying a form for the first time. It tells Spring the
 	 * form/command object to load into the request
+	 * <p>
+	 * <b>Should</b> catch an invalid birthdate.<br>
+	 * <b>Should</b> catch pass for a valid birthdate.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.AbstractFormController#formBackingObject(javax.servlet.http.HttpServletRequest)
-	 * @should catch an invalid birthdate
-	 * @should catch pass for a valid birthdate
 	 */
 	@Override
 	protected List<PersonListItem> formBackingObject(HttpServletRequest request) throws ServletException {

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeFormController.java
@@ -41,10 +41,13 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for adding/editing a single PersonAttributeType
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_PERSON_ATTRIBUTE_TYPES)
 public class PersonAttributeTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeListController.java
@@ -33,12 +33,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Controls the moving/deleting of {@link PersonAttributeType}s.
  */
 @Controller
 @RequestMapping(value = "/admin/person/personAttributeType.list")
+@RequirePrivilege(PrivilegeConstants.MANAGE_PERSON_ATTRIBUTE_TYPES)
 public class PersonAttributeTypeListController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonAttributeTypeListController.java
@@ -48,9 +48,9 @@ public class PersonAttributeTypeListController {
 	
 	/**
 	 * Show the page to the user.
-	 * 
-	 * @should not fail if not authenticated
-	 * @should put all attribute types into map
+	 * <p>
+	 * <b>Should</b> not fail if not authenticated.<br>
+	 * <b>Should</b> put all attribute types into map.
 	 */
 	@SuppressWarnings("unchecked")
 	@RequestMapping(method = RequestMethod.GET)
@@ -90,6 +90,8 @@ public class PersonAttributeTypeListController {
 	
 	/**
 	 * The user has selected the bottom save button to update the GPs
+	 * <p>
+	 * <b>Should</b> save given personListingAttributeTypes.
 	 * 
 	 * @param patientListingAttributeTypes patient list gp
 	 * @param patientViewingAttributeTypes patient viewing gp
@@ -97,7 +99,6 @@ public class PersonAttributeTypeListController {
 	 * @param userListingAttributeTypes user listing gp
 	 * @param userViewingAttributeTypes user viewing gp
 	 * @param httpSession the current session
-	 * @should save given personListingAttributeTypes
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = "action=attrs")
 	protected String updateGlobalProperties(String patientListingAttributeTypes, String patientViewingAttributeTypes,
@@ -124,12 +125,13 @@ public class PersonAttributeTypeListController {
 	
 	/**
 	 * Moves the selected types up one in the order
+	 * <p>
+	 * <b>Should</b> move selected ids up one in the list.<br>
+	 * <b>Should</b> not fail if given first id.<br>
+	 * <b>Should</b> not fail if not given any ids.
 	 * 
 	 * @param personAttributeTypeId list of ids to move up
 	 * @param httpSession the current session
-	 * @should move selected ids up one in the list
-	 * @should not fail if given first id
-	 * @should not fail if not given any ids
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = "action=moveup")
 	public String moveUp(Integer[] personAttributeTypeId, HttpSession httpSession) {
@@ -173,12 +175,13 @@ public class PersonAttributeTypeListController {
 	
 	/**
 	 * Moves the selected types down in the order
+	 * <p>
+	 * <b>Should</b> move selected ids down in the list.<br>
+	 * <b>Should</b> not fail if given last id.<br>
+	 * <b>Should</b> not fail if not given any ids.
 	 * 
 	 * @param personAttributeTypeId list of ids to move down
 	 * @param httpSession the current session
-	 * @should move selected ids down in the list
-	 * @should not fail if given last id
-	 * @should not fail if not given any ids
 	 */
 	@RequestMapping(method = RequestMethod.POST, params = "action=movedown")
 	public String moveDown(Integer[] personAttributeTypeId, HttpSession httpSession) {

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.person;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 public class PersonController {
 	
 	@RequestMapping(value = "admin/person/index")

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonDashboardController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonDashboardController.java
@@ -17,10 +17,13 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Person;
 import org.openmrs.api.context.Context;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  *
  */
+@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 public class PersonDashboardController extends SimpleFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/PersonFormController.java
@@ -58,6 +58,8 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This class controls the generic person properties (address, name, attributes). The Patient and
@@ -65,6 +67,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * 
  * @see org.openmrs.web.controller.patient.PatientFormController
  */
+@RequirePrivilege(PrivilegeConstants.EDIT_PERSONS)
 public class PersonFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeFormController.java
@@ -30,7 +30,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES)
 public class RelationshipTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeListController.java
@@ -28,7 +28,10 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES)
 public class RelationshipTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeViewFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/person/RelationshipTypeViewFormController.java
@@ -34,11 +34,14 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This is the controller for the relationshipTypeView.form page. It controls the way that
  * relationship types are viewed in openmrs.
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_RELATIONSHIP_TYPES)
 public class RelationshipTypeViewFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/program/PatientProgramFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/PatientProgramFormController.java
@@ -37,8 +37,11 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.EDIT_PATIENT_PROGRAMS)
 public class PatientProgramFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/program/ProgramFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/ProgramFormController.java
@@ -28,7 +28,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROGRAMS)
 public class ProgramFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/program/ProgramFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/ProgramFormController.java
@@ -76,12 +76,13 @@ public class ProgramFormController extends SimpleFormController {
 	/**
 	 * The onSubmit function receives the form/command object that was modified by the input form
 	 * and saves it to the db
+	 * <p>
+	 * <b>Should</b> save workflows with program.<br>
+	 * <b>Should</b> edit existing workflows within programs.
 	 * 
 	 * @see org.springframework.web.servlet.mvc.SimpleFormController#onSubmit(javax.servlet.http.HttpServletRequest,
 	 *      javax.servlet.http.HttpServletResponse, java.lang.Object,
 	 *      org.springframework.validation.BindException)
-	 * @should save workflows with program
-	 * @should edit existing workflows within programs
 	 */
 	protected ModelAndView onSubmit(HttpServletRequest request, HttpServletResponse response, Object obj,
 	        BindException errors) throws Exception {

--- a/omod/src/main/java/org/openmrs/web/controller/program/ProgramListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/ProgramListController.java
@@ -29,7 +29,10 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROGRAMS)
 public class ProgramListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/program/StateConversionFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/StateConversionFormController.java
@@ -34,7 +34,10 @@ import org.springframework.web.bind.ServletRequestUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROGRAMS)
 public class StateConversionFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/program/StateConversionListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/StateConversionListController.java
@@ -29,7 +29,10 @@ import org.springframework.validation.BindException;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROGRAMS)
 public class StateConversionListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/program/WorkflowFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/program/WorkflowFormController.java
@@ -36,7 +36,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROGRAMS)
 public class WorkflowFormController extends SimpleFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/provider/ManageProviderController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/provider/ManageProviderController.java
@@ -11,8 +11,11 @@ package org.openmrs.web.controller.provider;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROVIDERS)
 public class ManageProviderController {
 	
 	@RequestMapping(value = "admin/provider/index")

--- a/omod/src/main/java/org/openmrs/web/controller/provider/ProviderAttributeTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/provider/ProviderAttributeTypeFormController.java
@@ -32,12 +32,15 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for editing visit attribute types.
  * 
  * @since 1.9
  */
+@RequirePrivilege(value = { PrivilegeConstants.MANAGE_PROVIDERS,PrivilegeConstants.PURGE_PROVIDERS }, requireAll = true)
 public class ProviderAttributeTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/provider/ProviderAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/provider/ProviderAttributeTypeListController.java
@@ -23,12 +23,15 @@ import org.openmrs.api.context.Context;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing provider attribute types.
  * 
  * @since 1.9
  */
+@RequirePrivilege(value = { PrivilegeConstants.MANAGE_PROVIDERS,PrivilegeConstants.PURGE_PROVIDERS }, requireAll = true)
 public class ProviderAttributeTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/provider/ProviderFormController.java
@@ -34,9 +34,12 @@ import org.springframework.web.bind.annotation.RequestParam;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
 @RequestMapping("/admin/provider/provider.form")
+@RequirePrivilege(PrivilegeConstants.MANAGE_PROVIDERS)
 public class ProviderFormController {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/query/LocationQueryController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/query/LocationQueryController.java
@@ -27,11 +27,14 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * This class contains ajax-accessible queries relating to Locations
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 public class LocationQueryController {
 	
 	@RequestMapping("/q/locationHierarchy")

--- a/omod/src/main/java/org/openmrs/web/controller/remotecommunication/PostHl7Controller.java
+++ b/omod/src/main/java/org/openmrs/web/controller/remotecommunication/PostHl7Controller.java
@@ -24,7 +24,10 @@ import org.openmrs.hl7.HL7Source;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.Controller;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE)
 public class PostHl7Controller implements Controller {
 	
 	protected final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/user/ChangePasswordFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/ChangePasswordFormController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Used for changing the password when the force password change option is set during a new user
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestParam;
  */
 @Controller
 @RequestMapping(value = "/admin/users/changePassword.form")
+@RequirePrivilege
 public class ChangePasswordFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/user/ChangePasswordFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/ChangePasswordFormController.java
@@ -41,8 +41,9 @@ public class ChangePasswordFormController {
 	
 	/**
 	 * The model from which the data binding happens on the view
+	 * <p>
+	 * <b>Should</b> return an authenticated User.
 	 * 
-	 * @should return an authenticated User
 	 * @return authenticated user
 	 */
 	@ModelAttribute("user")
@@ -66,19 +67,23 @@ public class ChangePasswordFormController {
 	/**
 	 * Method to save changes of the new password for a user. The password will be validated against
 	 * the current rules and will display error messages in case the password is not strong enough.
+	 * <p>
+	 * <b>Should</b> display an error message when the password and confirm password entries are
+	 * different.<br>
+	 * <b>Should</b> not display error message if password and confirm password are the same.<br>
+	 * <b>Should</b> display error message when the password is empty.<br>
+	 * <b>Should</b> display error message if password is weak.<br>
+	 * <b>Should</b> display error message when question is empty and answer is not empty.<br>
+	 * <b>Should</b> display error message when the answer and the confirm answer entered are not
+	 * the same.<br>
+	 * <b>Should</b> display error message when the answer is empty and question is not empty.<br>
+	 * <b>Should</b> navigate to the home page if the authentication is successful.<br>
+	 * <b>Should</b> set the user property forcePassword to false after successful password change.<br>
+	 * <b>Should</b> not set the user property forcePassword to false after unsuccessful password
+	 * change.<br>
+	 * <b>Should</b> remain on the changePasswordForm page if there are errors.<br>
+	 * <b>Should</b> set the secret question and answer of the user.
 	 * 
-	 * @should display an error message when the password and confirm password entries are different
-	 * @should not display error message if password and confirm password are the same
-	 * @should display error message when the password is empty
-	 * @should display error message if password is weak
-	 * @should display error message when question is empty and answer is not empty
-	 * @should display error message when the answer and the confirm answer entered are not the same
-	 * @should display error message when the answer is empty and question is not empty
-	 * @should navigate to the home page if the authentication is successful
-	 * @should set the user property forcePassword to false after successful password change
-	 * @should not set the user property forcePassword to false after unsuccessful password change
-	 * @should remain on the changePasswordForm page if there are errors
-	 * @should set the secret question and answer of the user
 	 * @param password to be applied
 	 * @param confirmPassword confirmation for the password to be applied
 	 * @param question in case of a forgotten password

--- a/omod/src/main/java/org/openmrs/web/controller/user/PrivilegeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/PrivilegeFormController.java
@@ -26,7 +26,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PRIVILEGES)
 public class PrivilegeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/user/PrivilegeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/PrivilegeListController.java
@@ -32,7 +32,10 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_PRIVILEGES)
 public class PrivilegeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/user/RoleFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/RoleFormController.java
@@ -40,7 +40,10 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ROLES)
 public class RoleFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/user/RoleListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/RoleListController.java
@@ -36,7 +36,10 @@ import javax.servlet.http.HttpSession;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.MANAGE_ROLES)
 public class RoleListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/user/UserController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/UserController.java
@@ -14,7 +14,10 @@ import org.springframework.web.servlet.mvc.SimpleFormController;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
+@RequirePrivilege(PrivilegeConstants.EDIT_USERS)
 public class UserController extends SimpleFormController {
 	
 	/**

--- a/omod/src/main/java/org/openmrs/web/controller/user/UserFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/UserFormController.java
@@ -47,11 +47,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Used for creating/editing User
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.EDIT_USERS)
 public class UserFormController {
 	
 	protected static final Log log = LogFactory.getLog(UserFormController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/user/UserFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/UserFormController.java
@@ -145,7 +145,8 @@ public class UserFormController {
 	}
 	
 	/**
-	 * @should work for an example
+	 * <p>
+	 * <b>Should</b> work for an example.
 	 */
 	@RequestMapping(value = "/admin/users/user.form", method = RequestMethod.POST)
 	public String handleSubmission(WebRequest request, HttpSession httpSession, ModelMap model,

--- a/omod/src/main/java/org/openmrs/web/controller/user/UserListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/UserListController.java
@@ -27,8 +27,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 @Controller
+@RequirePrivilege(PrivilegeConstants.EDIT_USERS)
 public class UserListController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/user/UserListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/user/UserListController.java
@@ -38,10 +38,11 @@ public class UserListController {
 	protected final Log log = LogFactory.getLog(getClass());
 	
 	/**
-	 * @should get users just given action parameter
-	 * @should get all users if no name given
-	 * @should get users with a given role
-	 * @should include disabled users if requested
+	 * <p>
+	 * <b>Should</b> get users just given action parameter.<br>
+	 * <b>Should</b> get all users if no name given.<br>
+	 * <b>Should</b> get users with a given role.<br>
+	 * <b>Should</b> include disabled users if requested.
 	 */
 	@RequestMapping(value = "/admin/users/users.list")
 	public String displayUsers(ModelMap model, @RequestParam(value = "action", required = false) String action,

--- a/omod/src/main/java/org/openmrs/web/controller/visit/ConfigureVisitsFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/ConfigureVisitsFormController.java
@@ -39,12 +39,14 @@ import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This class controls the configureVisits.form jsp page. See
  * /web/WEB-INF/view/admin/visits/configureVisits.jsp
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.CONFIGURE_VISITS)
 public class ConfigureVisitsFormController {
 	
 	public static final String CONFIGURE_VISITS_PATH = "/admin/visits/configureVisits.list";

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitAttributeTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitAttributeTypeFormController.java
@@ -32,6 +32,8 @@ import org.springframework.validation.Errors;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for editing visit attribute types.
@@ -39,6 +41,7 @@ import org.springframework.web.servlet.view.RedirectView;
  * @since 1.9
  */
 @SuppressWarnings("deprecation")
+@RequirePrivilege(value = { PrivilegeConstants.MANAGE_VISIT_ATTRIBUTE_TYPES,PrivilegeConstants.PURGE_VISIT_ATTRIBUTE_TYPES }, requireAll = true)
 public class VisitAttributeTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitAttributeTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitAttributeTypeListController.java
@@ -23,12 +23,15 @@ import org.openmrs.api.context.Context;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing visit attribute types.
  * 
  * @since 1.9
  */
+@RequirePrivilege(value = { PrivilegeConstants.MANAGE_VISIT_ATTRIBUTE_TYPES,PrivilegeConstants.PURGE_VISIT_ATTRIBUTE_TYPES }, requireAll = true)
 public class VisitAttributeTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitFormController.java
@@ -47,11 +47,14 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.context.request.WebRequest;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller class for creating, editing, deleting, restoring and purging a visit
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.EDIT_VISITS)
 public class VisitFormController {
 	
 	private static final Log log = LogFactory.getLog(VisitFormController.class);

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitListController.java
@@ -34,11 +34,14 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Lists visits.
  */
 @Controller
+@RequirePrivilege(PrivilegeConstants.GET_VISITS)
 public class VisitListController {
 	
 	protected final Logger log = Logger.getLogger(getClass());

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitTypeFormController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitTypeFormController.java
@@ -29,12 +29,15 @@ import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.SimpleFormController;
 import org.springframework.web.servlet.view.RedirectView;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for editing visit types.
  * 
  * @since 1.9
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_VISIT_TYPES)
 public class VisitTypeFormController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/controller/visit/VisitTypeListController.java
+++ b/omod/src/main/java/org/openmrs/web/controller/visit/VisitTypeListController.java
@@ -23,12 +23,15 @@ import org.openmrs.api.context.Context;
 import org.springframework.beans.propertyeditors.CustomNumberEditor;
 import org.springframework.web.bind.ServletRequestDataBinder;
 import org.springframework.web.servlet.mvc.SimpleFormController;
+import org.openmrs.web.security.RequirePrivilege;
+import org.openmrs.util.PrivilegeConstants;
 
 /**
  * Controller for listing visit types.
  * 
  * @since 1.9
  */
+@RequirePrivilege(PrivilegeConstants.MANAGE_VISIT_TYPES)
 public class VisitTypeListController extends SimpleFormController {
 	
 	/** Logger for this class and subclasses */

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRAdministrationService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRAdministrationService.java
@@ -11,6 +11,8 @@ package org.openmrs.web.dwr;
 
 import org.openmrs.GlobalProperty;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  *
@@ -23,6 +25,7 @@ public class DWRAdministrationService {
 	 * @param name
 	 * @return property value
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_GLOBAL_PROPERTIES)
 	public String getGlobalProperty(String name) {
 		return Context.getAdministrationService().getGlobalProperty(name);
 	}
@@ -33,6 +36,7 @@ public class DWRAdministrationService {
 	 * @param name
 	 * @param newValue
 	 */
+	@RequirePrivilege(PrivilegeConstants.MANAGE_GLOBAL_PROPERTIES)
 	public void setGlobalProperty(String name, String newValue) {
 		Context.getAdministrationService().saveGlobalProperty(new GlobalProperty(name, newValue));
 	}

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRCohortService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRCohortService.java
@@ -16,6 +16,8 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Cohort;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * This class exposes some of the methods in {@link org.openmrs.api.CohortService} via the dwr
@@ -32,6 +34,7 @@ public class DWRCohortService {
 	 * @param cohortId - Identifies the {@link Cohort} to add to
 	 * @param patientId - Identifies the {@link Patient} to add
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_COHORTS)
 	public void addPatientToCohort(Integer cohortId, Integer patientId) {
 		Patient p = Context.getPatientService().getPatient(patientId);
 		Cohort c = Context.getCohortService().getCohort(cohortId);
@@ -45,6 +48,7 @@ public class DWRCohortService {
 	 * @param cohortId - Identifies the {@link Cohort} to remove from
 	 * @param patientId - Identifies the {@link Patient} to remove
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_COHORTS)
 	public void removePatientFromCohort(Integer cohortId, Integer patientId) {
 		Patient p = Context.getPatientService().getPatient(patientId);
 		Cohort c = Context.getCohortService().getCohort(cohortId);
@@ -56,6 +60,7 @@ public class DWRCohortService {
 	 * 
 	 * @return Vector&lt;ListItem&gt; - all saved Cohorts
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_COHORTS)
 	public Vector<ListItem> getCohorts() {
 		Vector<ListItem> ret = new Vector<ListItem>();
 		for (Cohort c : Context.getCohortService().getAllCohorts()) {
@@ -72,6 +77,7 @@ public class DWRCohortService {
 	 * @return Vector&lt;ListItem&gt; - of all saved Cohorts containing the {@link Patient}
 	 *         identified by <code>patientId</code>
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_COHORTS)
 	public Vector<ListItem> getCohortsContainingPatient(Integer patientId) {
 		Vector<ListItem> ret = new Vector<ListItem>();
 		for (Cohort c : Context.getCohortService().getCohortsContainingPatientId(patientId)) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
@@ -45,7 +45,9 @@ import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.ConceptReferenceTermValidator;
+import org.openmrs.web.security.RequirePrivilege;
 import org.owasp.encoder.Encode;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
@@ -73,6 +75,7 @@ public class DWRConceptService {
 	 * @param includeDrugConcepts Specifies if drugs with matching conceptNames should be included
 	 * @return a list of conceptListItems matching the given arguments
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> findConcepts(String phrase, boolean includeRetired, List<String> includeClassNames,
 	        List<String> excludeClassNames, List<String> includeDatatypeNames, List<String> excludeDatatypeNames,
 	        boolean includeDrugConcepts) {
@@ -103,6 +106,7 @@ public class DWRConceptService {
 	 * @should not return duplicates when searching by concept id
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> findBatchOfConcepts(String phrase, boolean includeRetired, List<String> includeClassNames,
 	        List<String> excludeClassNames, List<String> includeDatatypeNames, List<String> excludeDatatypeNames,
 	        Integer start, Integer length) {
@@ -253,6 +257,7 @@ public class DWRConceptService {
 	 * @param conceptId the id to look for
 	 * @return a {@link ConceptListItem} or null if conceptId is not found
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public ConceptListItem getConcept(Integer conceptId) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -266,6 +271,7 @@ public class DWRConceptService {
 		return new ConceptListItem(c, cn, locale);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPT_PROPOSALS)
 	public List<ConceptListItem> findProposedConcepts(String text) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -295,6 +301,7 @@ public class DWRConceptService {
 	 * @should search for concept answers in all search locales
 	 * @should not return duplicates
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> findConceptAnswers(String text, Integer conceptId, boolean includeVoided, boolean includeDrugConcepts)
 	        throws Exception {
 		
@@ -351,6 +358,7 @@ public class DWRConceptService {
 		return items;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> getConceptSet(Integer conceptId) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -386,6 +394,7 @@ public class DWRConceptService {
 		return returnList;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<ConceptListItem> getQuestionsForAnswer(Integer conceptId) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -403,6 +412,7 @@ public class DWRConceptService {
 		return items;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public ConceptDrugListItem getDrug(Integer drugId) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -411,6 +421,7 @@ public class DWRConceptService {
 		return d == null ? null : new ConceptDrugListItem(d, locale);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> getDrugs(Integer conceptId, boolean showConcept) {
 		Locale locale = Context.getLocale();
 		ConceptService cs = Context.getConceptService();
@@ -444,6 +455,7 @@ public class DWRConceptService {
 		return items;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> findDrugs(String phrase, boolean includeRetired) throws APIException {
 		if (includeRetired) {
 			throw new APIException("you.should.not.included.voideds", (Object[]) null);
@@ -468,18 +480,21 @@ public class DWRConceptService {
 		return items;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public boolean isValidNumericValue(Float value, Integer conceptId) {
 		ConceptNumeric conceptNumeric = Context.getConceptService().getConceptNumeric(conceptId);
 		
 		return OpenmrsUtil.isValidNumericValue(value, conceptNumeric);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public String getConceptNumericUnits(Integer conceptId) {
 		ConceptNumeric conceptNumeric = Context.getConceptService().getConceptNumeric(conceptId);
 		
 		return conceptNumeric.getUnits();
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<ConceptListItem> getAnswersForQuestion(Integer conceptId) {
 		List<ConceptListItem> ret = new ArrayList<ConceptListItem>();
 		Concept c = Context.getConceptService().getConcept(conceptId);
@@ -502,6 +517,7 @@ public class DWRConceptService {
 	 * @param conceptId the conceptId of the concept to be converted
 	 * @return String to act as a signal if successfully converted or an error message
 	 */
+	@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPTS)
 	public String convertBooleanConceptToCoded(Integer conceptId) {
 		
 		try {
@@ -539,6 +555,7 @@ public class DWRConceptService {
 	 * @throws APIException
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public Map<String, Object> findCountAndConcepts(String phrase, boolean includeRetired, List<String> includeClassNames,
 	        List<String> excludeClassNames, List<String> includeDatatypeNames, List<String> excludeDatatypeNames,
 	        Integer start, Integer length, boolean getMatchCount) throws APIException {
@@ -663,6 +680,7 @@ public class DWRConceptService {
 	 * @param conceptReferenceTermId the id to look for
 	 * @return a {@link ConceptReferenceTermListItem} or null if conceptReferenceTermId is not found
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
 	public ConceptReferenceTermListItem getConceptReferenceTerm(Integer conceptReferenceTermId) {
 		ConceptReferenceTerm term = Context.getConceptService().getConceptReferenceTerm(conceptReferenceTermId);
 		if (term == null) {
@@ -682,6 +700,7 @@ public class DWRConceptService {
 	 * @param includeRetired Specifies if retired concept reference terms should be included or not
 	 * @return a {@link List} of {@link ConceptReferenceTermListItem}
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
 	public List<Object> findBatchOfConceptReferenceTerms(String phrase, Integer sourceId, Integer start, Integer length,
 	        boolean includeRetired) {
 		List<Object> objectList = new ArrayList<Object>();
@@ -731,6 +750,7 @@ public class DWRConceptService {
 	 * @return map with keys "count" and "objectList"
 	 * @throws APIException
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_CONCEPT_REFERENCE_TERMS)
 	public Map<String, Object> findCountAndConceptReferenceTerms(String phrase, Integer sourceId, Integer start,
 	        Integer length, boolean includeRetired, boolean getMatchCount) throws APIException {
 		//Map to return
@@ -774,6 +794,7 @@ public class DWRConceptService {
 	 * @param name the unique name for the reference term
 	 * @return a list of error messages
 	 */
+	@RequirePrivilege(PrivilegeConstants.MANAGE_CONCEPT_REFERENCE_TERMS)
 	public List<String> createConceptReferenceTerm(String code, Integer conceptSourceId, String name) {
 		List<String> errors = new ArrayList<String>();
 		MessageSourceService mss = Context.getMessageSourceService();

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRConceptService.java
@@ -85,6 +85,16 @@ public class DWRConceptService {
 	
 	/**
 	 * Gets a list of conceptListItems matching the given arguments
+	 * <p>
+	 * <b>Should</b> return concept by given id if exclude and include lists are empty.<br>
+	 * <b>Should</b> return concept by given id if classname is included.<br>
+	 * <b>Should</b> not return concept by given id if classname is not included.<br>
+	 * <b>Should</b> not return concept by given id if classname is excluded.<br>
+	 * <b>Should</b> return concept by given id if datatype is included.<br>
+	 * <b>Should</b> not return concept by given id if datatype is not included.<br>
+	 * <b>Should</b> not return concept by given id if datatype is excluded.<br>
+	 * <b>Should</b> include.<br>
+	 * <b>Should</b> not return duplicates when searching by concept id.
 	 * 
 	 * @param phrase the concept name string to match against
 	 * @param includeRetired boolean if false, will exclude retired concepts
@@ -95,15 +105,6 @@ public class DWRConceptService {
 	 * @param start the beginning index
 	 * @param length the number of matching concepts to return
 	 * @return a list of conceptListItems matching the given arguments
-	 * @should return concept by given id if exclude and include lists are empty
-	 * @should return concept by given id if classname is included
-	 * @should not return concept by given id if classname is not included
-	 * @should not return concept by given id if classname is excluded
-	 * @should return concept by given id if datatype is included
-	 * @should not return concept by given id if datatype is not included
-	 * @should not return concept by given id if datatype is excluded
-	 * @should include
-	 * @should not return duplicates when searching by concept id
 	 * @since 1.8
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
@@ -288,6 +289,11 @@ public class DWRConceptService {
 	/**
 	 * Find a list of {@link ConceptListItem} or {@link ConceptDrugListItem}s that are answers to
 	 * the given question. The given question is determined by the given <code>conceptId</code>
+	 * <p>
+	 * <b>Should</b> not fail if the specified concept has no answers (regression test for
+	 * TRUNK-2807).<br>
+	 * <b>Should</b> search for concept answers in all search locales.<br>
+	 * <b>Should</b> not return duplicates.
 	 * 
 	 * @param text the text to search for within the answers
 	 * @param conceptId the conceptId of the question concept
@@ -297,9 +303,6 @@ public class DWRConceptService {
 	 * @return list of {@link ConceptListItem} or {@link ConceptDrugListItem} answers that match the
 	 *         query
 	 * @throws Exception if given conceptId is not found
-	 * @should not fail if the specified concept has no answers (regression test for TRUNK-2807)
-	 * @should search for concept answers in all search locales
-	 * @should not return duplicates
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_CONCEPTS)
 	public List<Object> findConceptAnswers(String text, Integer conceptId, boolean includeVoided, boolean includeDrugConcepts)

--- a/omod/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWREncounterService.java
@@ -23,6 +23,8 @@ import org.openmrs.api.EncounterService;
 import org.openmrs.api.LocationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 import org.owasp.encoder.Encode;
 
 public class DWREncounterService {
@@ -38,6 +40,7 @@ public class DWREncounterService {
 	 * @return list of the matching encounters
 	 * @throws APIException
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 	public Vector findEncounters(String phrase, boolean includeVoided) throws APIException {
 		
 		return findBatchOfEncounters(phrase, includeVoided, null, null);
@@ -56,6 +59,7 @@ public class DWREncounterService {
 	 * @throws APIException
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 	public Vector findBatchOfEncounters(String phrase, boolean includeVoided, Integer start, Integer length)
 	        throws APIException {
 		return findBatchOfEncountersByPatient(phrase, null, includeVoided, null, null);
@@ -77,6 +81,7 @@ public class DWREncounterService {
 	 * @since 1.10
 	 */
 	@SuppressWarnings("rawtypes")
+	@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 	public Vector findBatchOfEncountersByPatient(String phrase, Integer patientId, boolean includeVoided, Integer start,
 	        Integer length) throws APIException {
 		
@@ -146,6 +151,7 @@ public class DWREncounterService {
 	 * @since 1.8
 	 */
 	@SuppressWarnings("unchecked")
+	@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 	public Map<String, Object> findCountAndEncounters(String phrase, boolean includeVoided, Integer start, Integer length,
 	        boolean getMatchCount) throws APIException {
 		//Map to return
@@ -187,6 +193,7 @@ public class DWREncounterService {
 		return resultsMap;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_ENCOUNTERS)
 	public EncounterListItem getEncounter(Integer encounterId) {
 		EncounterService es = Context.getEncounterService();
 		Encounter e = es.getEncounter(encounterId);
@@ -194,6 +201,7 @@ public class DWREncounterService {
 		return e == null ? null : new EncounterListItem(e);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 	public Vector findLocations(String searchValue) {
 		
 		return findBatchOfLocations(searchValue, false, null, null);
@@ -212,6 +220,7 @@ public class DWREncounterService {
 	 * @throws APIException
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 	public Vector<Object> findBatchOfLocations(String searchValue, boolean includeRetired, Integer start, Integer length)
 	        throws APIException {
 		
@@ -240,6 +249,7 @@ public class DWREncounterService {
 	}
 	
 	@SuppressWarnings("unchecked")
+	@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 	public Vector getLocations() {
 		
 		Vector locationList = new Vector();
@@ -263,6 +273,7 @@ public class DWREncounterService {
 		return locationList;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 	public LocationListItem getLocation(Integer locationId) {
 		LocationService ls = Context.getLocationService();
 		Location l = ls.getLocation(locationId);
@@ -284,6 +295,7 @@ public class DWREncounterService {
 	 * @throws APIException
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_LOCATIONS)
 	public Map<String, Object> findCountAndLocations(String phrase, boolean includeRetired, Integer start, Integer length,
 	        boolean getMatchCount) throws APIException {
 		

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRFormService.java
@@ -31,7 +31,9 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.FormService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.FormUtil;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebUtil;
+import org.openmrs.web.security.RequirePrivilege;
 import org.owasp.encoder.Encode;
 
 /**
@@ -50,6 +52,7 @@ public class DWRFormService {
 	 * @param includeUnpublished true/false whether to include unpublished forms
 	 * @return list of {@link FormListItem}s
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public List<FormListItem> findForms(String text, boolean includeUnpublished) {
 		List<FormListItem> forms = new Vector<FormListItem>();
 		
@@ -67,6 +70,7 @@ public class DWRFormService {
 	 * @param includeUnpublished true/false to include unpublished forms
 	 * @return list of {@link FormListItem}s
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public List<FormListItem> getForms(boolean includeUnpublished) {
 		List<FormListItem> formListItems = new Vector<FormListItem>();
 		
@@ -80,6 +84,7 @@ public class DWRFormService {
 		return formListItems;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public Field getField(Integer fieldId) {
 		Field f;
 		FormService fs = Context.getFormService();
@@ -87,6 +92,7 @@ public class DWRFormService {
 		return f;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public FormFieldListItem getFormField(Integer formFieldId) {
 		FormField f;
 		FormService fs = Context.getFormService();
@@ -94,6 +100,7 @@ public class DWRFormService {
 		return new FormFieldListItem(f, Context.getLocale());
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public List<FormFieldListItem> getFormFields(Integer formId) {
 		List<FormFieldListItem> formFields = new Vector<FormFieldListItem>();
 		Form form = Context.getFormService().getForm(formId);
@@ -103,6 +110,7 @@ public class DWRFormService {
 		return formFields;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public List<FieldListItem> findFields(String txt) {
 		List<FieldListItem> fields = new Vector<FieldListItem>();
 		
@@ -123,6 +131,7 @@ public class DWRFormService {
 		return fields;
 	}
 	
+	@RequirePrivilege(value = { PrivilegeConstants.GET_FORMS, PrivilegeConstants.GET_CONCEPTS }, requireAll = true)
 	public List<Object> findFieldsAndConcepts(String txt) {
 		Locale locale = Context.getLocale();
 		
@@ -189,12 +198,14 @@ public class DWRFormService {
 		return objects;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_FORMS)
 	public String getJSTree(Integer formId) {
 		Form form = Context.getFormService().getForm(formId);
 		Map<Integer, TreeSet<FormField>> formFields = FormUtil.getFormStructure(form);
 		return generateJSTree(formFields, 0, Context.getLocale());
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 	public Integer[] saveFormField(Integer fieldId, String name, String fieldDesc, Integer fieldTypeId, Integer conceptId,
 	        String table, String attr, String defaultValue, boolean multiple, Integer formFieldId, Integer formId,
 	        Integer parent, Integer number, String part, Integer page, Integer min, Integer max, boolean required,
@@ -265,6 +276,7 @@ public class DWRFormService {
 		return arr;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.MANAGE_FORMS)
 	public void deleteFormField(Integer id) {
 		if (Context.isAuthenticated()) {
 			Context.getFormService().purgeFormField(Context.getFormService().getFormField(id));

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRHL7Service.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRHL7Service.java
@@ -16,6 +16,8 @@ import org.openmrs.api.APIAuthenticationException;
 import org.openmrs.api.context.Context;
 import org.openmrs.hl7.Hl7InArchivesMigrateThread;
 import org.openmrs.hl7.Hl7InArchivesMigrateThread.Status;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * DWR archive migration methods. The methods in here are used in the webapp to start and stop the
@@ -36,6 +38,9 @@ public class DWRHL7Service {
 	 * @return an object array with a boolean value at index 0 indicating if the migration was
 	 *         started or not, at the second index is an optional descriptive message.
 	 */
+	@RequirePrivilege(value = { PrivilegeConstants.GET_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE }, requireAll = true)
 	public Object[] startHl7ArchiveMigration(Integer daysToKeep) {
 		if (Hl7InArchivesMigrateThread.isActive()) {
 			return new Object[] { false,
@@ -62,6 +67,9 @@ public class DWRHL7Service {
 	 * 
 	 * @return a descriptive message
 	 */
+	@RequirePrivilege(value = { PrivilegeConstants.GET_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE }, requireAll = true)
 	public String stopHl7ArchiveMigration() {
 		Hl7InArchivesMigrateThread.stopMigration();
 		setHl7MigrationThread(null);
@@ -74,6 +82,9 @@ public class DWRHL7Service {
 	 * @return a map containing the number migrated, the state of the migrate thread at a given time
 	 *         when it is running and a message string.
 	 */
+	@RequirePrivilege(value = { PrivilegeConstants.GET_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_PURGE_HL7_IN_ARCHIVE,
+	        PrivilegeConstants.PRIV_ADD_HL7_IN_QUEUE }, requireAll = true)
 	public Map<String, Object> getMigrationStatus() {
 		Map<String, Object> statusMap = new HashMap<String, Object>();
 		statusMap.put("numberMigrated", Hl7InArchivesMigrateThread.getNumberTransferred());

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRObsService.java
@@ -30,6 +30,8 @@ import org.openmrs.Person;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  *
@@ -44,6 +46,7 @@ public class DWRObsService {
 	 * @param obsId
 	 * @param reason
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_OBS)
 	public void voidObservation(Integer obsId, String reason) {
 		Obs obs = Context.getObsService().getObs(obsId);
 		if (obs == null) {
@@ -62,6 +65,7 @@ public class DWRObsService {
 	 * @param encounterId
 	 * @return list of observations
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_OBS)
 	public Vector<Object> getObservations(Integer encounterId) {
 		
 		log.info("Get observations for encounter " + encounterId);
@@ -97,6 +101,7 @@ public class DWRObsService {
 	 * @param valueText
 	 * @param obsDateStr
 	 */
+	@RequirePrivilege(PrivilegeConstants.ADD_OBS)
 	public void createObs(Integer personId, Integer encounterId, Integer conceptId, String valueText, String obsDateStr)
 	        throws Exception {
 		createNewObs(personId, encounterId, null, conceptId, valueText, obsDateStr);
@@ -112,6 +117,7 @@ public class DWRObsService {
 	 * @param valueText
 	 * @param obsDateStr
 	 */
+	@RequirePrivilege(PrivilegeConstants.ADD_OBS)
 	public void createNewObs(Integer personId, Integer encounterId, Integer locationId, Integer conceptId, String valueText,
 	        String obsDateStr) throws Exception {
 		
@@ -271,6 +277,7 @@ public class DWRObsService {
 	 * @param encounterId
 	 * @return list of obs items
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_OBS)
 	public Vector<ObsListItem> getObsByPatientConceptEncounter(String personId, String conceptId, String encounterId) {
 		log.debug("Started with: [" + personId + "] [" + conceptId + "] [" + encounterId + "]");
 		
@@ -334,6 +341,7 @@ public class DWRObsService {
 	 * @param obsId
 	 * @return list item or null
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_OBS)
 	public ObsListItem getObs(Integer obsId) {
 		Obs o = null;
 		if (obsId != null) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
@@ -44,7 +44,9 @@ import org.openmrs.module.legacyui.api.LegacyUIService;
 import org.openmrs.patient.IdentifierValidator;
 import org.openmrs.patient.UnallowedIdentifierException;
 import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebUtil;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * DWR patient methods. The methods in here are used in the webapp to get data from the database via
@@ -74,6 +76,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @should get results for patients that have edited themselves
 	 * @should logged in user should load their own patient object
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Collection<Object> findPatients(String searchValue, boolean includeVoided) {
 		return findBatchOfPatients(searchValue, includeVoided, null, null);
 	}
@@ -94,6 +97,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @return Collection&lt;Object&gt; of PatientListItem or String
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Collection<Object> findBatchOfPatients(String searchValue, boolean includeVoided, Integer start, Integer length) {
 		if (maximumResults == null) {
 			setMaximumResults(getMaximumSearchResults());
@@ -176,6 +180,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @return a map of results
 	 * @throws APIException
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Map<String, Object> findCountAndPatientsWithVoided(String searchValue, Integer start, Integer length,
 	        boolean getMatchCount, Boolean includeVoided) throws APIException {
 		
@@ -315,6 +320,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @should not signal for a new search if the new search value has no matches
 	 * @should match patient with identifiers that contain no digit
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Map<String, Object> findCountAndPatients(String searchValue, Integer start, Integer length, boolean getMatchCount)
 	        throws APIException {
 		return findCountAndPatientsWithVoided(searchValue, start, length, getMatchCount, false);
@@ -327,6 +333,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param patientId the {@link Patient#getPatientId()} to match on
 	 * @return a truncated Patient object in the form of a PatientListItem
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public PatientListItem getPatient(Integer patientId) {
 		PatientService ps = Context.getPatientService();
 		Patient p = ps.getPatient(patientId);
@@ -345,6 +352,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param identifiers
 	 * @return list of patientListItems
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Vector<Object> findPatientsByIdentifier(String[] identifiers) {
 		Vector<Object> patientList = new Vector<>();
 		for (String identifier : identifiers) {
@@ -362,6 +370,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param searchOn
 	 * @return list of patientListItems
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Vector<Object> findDuplicatePatients(String[] searchOn) {
 		Vector<Object> patientList = new Vector<Object>();
 		
@@ -396,6 +405,8 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param identifierLocationId
 	 * @return empty string or, in case of an error, a message key for the error description
 	 */
+	@RequirePrivilege(value = { PrivilegeConstants.ADD_PATIENT_IDENTIFIERS,
+	        PrivilegeConstants.EDIT_PATIENTS }, requireAll = true)
 	public String addIdentifier(Integer patientId, String identifierType, String identifier, Integer identifierLocationId) {
 		
 		String ret = "";
@@ -480,6 +491,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param otherReason
 	 * @return empty string or, in case of an error, a description of the error
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENTS)
 	public String exitPatientFromCare(Integer patientId, Integer exitReasonId, String exitDateStr,
 	        Integer causeOfDeathConceptId, String otherReason) {
 		log.debug("Entering exitfromcare with [" + patientId + "] [" + exitReasonId + "] [" + exitDateStr + "]");
@@ -618,6 +630,7 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @param locationId
 	 * @return empty string
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENTS)
 	public String changeHealthCenter(Integer patientId, Integer locationId) {
 		log.warn("Deprecated method in 'DWRPatientService.changeHealthCenter'");
 		

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPatientService.java
@@ -63,18 +63,19 @@ public class DWRPatientService implements GlobalPropertyListener {
 	/**
 	 * Search on the <code>searchValue</code>. If a number is in the search string, do an identifier
 	 * search. Else, do a name search
+	 * <p>
+	 * <b>Should</b> return only patient list items with nonnumeric search.<br>
+	 * <b>Should</b> return string warning if invalid patient identifier.<br>
+	 * <b>Should</b> not return string warning if searching with valid identifier.<br>
+	 * <b>Should</b> include string in results if doing extra decapitated search.<br>
+	 * <b>Should</b> not return duplicate patient list items if doing decapitated search.<br>
+	 * <b>Should</b> not do decapitated search if numbers are in the search string.<br>
+	 * <b>Should</b> get results for patients that have edited themselves.<br>
+	 * <b>Should</b> logged in user should load their own patient object.
 	 * 
 	 * @param searchValue string to be looked for
 	 * @param includeVoided true/false whether or not to included voided patients
 	 * @return Collection&lt;Object&gt; of PatientListItem or String
-	 * @should return only patient list items with nonnumeric search
-	 * @should return string warning if invalid patient identifier
-	 * @should not return string warning if searching with valid identifier
-	 * @should include string in results if doing extra decapitated search
-	 * @should not return duplicate patient list items if doing decapitated search
-	 * @should not do decapitated search if numbers are in the search string
-	 * @should get results for patients that have edited themselves
-	 * @should logged in user should load their own patient object
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Collection<Object> findPatients(String searchValue, boolean includeVoided) {
@@ -307,6 +308,12 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * matching patients (depending on values of start and length parameters) while the keys are are
 	 * 'count' and 'objectList' respectively, if the length parameter is not specified, then all
 	 * matches will be returned from the start index if specified.
+	 * <p>
+	 * <b>Should</b> signal for a new search if the new search value has matches and is a first
+	 * call.<br>
+	 * <b>Should</b> not signal for a new search if it is not the first ajax call.<br>
+	 * <b>Should</b> not signal for a new search if the new search value has no matches.<br>
+	 * <b>Should</b> match patient with identifiers that contain no digit.
 	 * 
 	 * @param searchValue patient name or identifier
 	 * @param start the beginning index
@@ -315,10 +322,6 @@ public class DWRPatientService implements GlobalPropertyListener {
 	 * @return a map of results
 	 * @throws APIException
 	 * @since 1.8
-	 * @should signal for a new search if the new search value has matches and is a first call
-	 * @should not signal for a new search if it is not the first ajax call
-	 * @should not signal for a new search if the new search value has no matches
-	 * @should match patient with identifiers that contain no digit
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PATIENTS)
 	public Map<String, Object> findCountAndPatients(String searchValue, Integer start, Integer length, boolean getMatchCount)

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
@@ -32,7 +32,9 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebUtil;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * DWR methods for ajaxy effects on {@link Person} objects.
@@ -54,6 +56,7 @@ public class DWRPersonService {
 	 * @param gender
 	 * @return list of people
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public List<?> getSimilarPeople(String name, String birthdate, String age, String gender) {
 		Vector<Object> personList;
 		
@@ -109,6 +112,7 @@ public class DWRPersonService {
 	 * @param includeVoided
 	 * @return list of people
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public List<?> findPeople(String searchPhrase, boolean includeVoided) {
 		return findPeopleByRoles(searchPhrase, includeVoided, null);
 	}
@@ -126,6 +130,7 @@ public class DWRPersonService {
 	 * @should match on patient identifiers
 	 * @should allow null roles parameter
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public List<Object> findPeopleByRoles(String searchPhrase, boolean includeVoided, String roles) {
 		return findBatchOfPeopleByRoles(searchPhrase, includeVoided, roles, null, null);
 	}
@@ -142,6 +147,7 @@ public class DWRPersonService {
 	 * @param gender
 	 * @return PersonListItem person stub created
 	 */
+	@RequirePrivilege(PrivilegeConstants.ADD_PERSONS)
 	public Object createPerson(String given, String middle, String family, String birthdate, String dateformat, String age,
 	        String gender) {
 		log.error(given + " " + middle + " " + family + " " + birthdate + " " + dateformat + " " + age + " " + gender);
@@ -189,6 +195,7 @@ public class DWRPersonService {
 	 * @param personId
 	 * @return person or null
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public PersonListItem getPerson(Integer personId) {
 		Person p = Context.getPersonService().getPerson(personId);
 		return PersonListItem.createBestMatch(p);
@@ -246,6 +253,7 @@ public class DWRPersonService {
 	 * @return list of persons that match the given searchPhrase. The PersonListItems
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public Vector<Object> findBatchOfPeopleByRoles(String searchPhrase, boolean includeRetired, String roles, Integer start,
 	        Integer length) {
 		Vector<Object> personList = new Vector<Object>();
@@ -317,6 +325,7 @@ public class DWRPersonService {
 	 * @throws APIException
 	 * @since 1.8
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public Map<String, Object> findCountAndPeople(String phrase, boolean includeRetired, String roles, Integer start,
 	        Integer length, boolean getMatchCount) throws APIException {
 		

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRPersonService.java
@@ -119,6 +119,9 @@ public class DWRPersonService {
 	
 	/**
 	 * Find Person objects based on the given searchPhrase
+	 * <p>
+	 * <b>Should</b> match on patient identifiers.<br>
+	 * <b>Should</b> allow null roles parameter.
 	 * 
 	 * @param searchPhrase partial name or partial identifier
 	 * @param includeVoided true/false whether to include the voided objects
@@ -127,8 +130,6 @@ public class DWRPersonService {
 	 *         contain as much information as possible about the matching persons, e.g. considering
 	 *         whether they are patients or users, which for example is useful for displaying
 	 *         patient identifiers in PersonSearch-widgets.
-	 * @should match on patient identifiers
-	 * @should allow null roles parameter
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PERSONS)
 	public List<Object> findPeopleByRoles(String searchPhrase, boolean includeVoided, String roles) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRProgramWorkflowService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRProgramWorkflowService.java
@@ -29,6 +29,8 @@ import org.openmrs.ProgramWorkflowState;
 import org.openmrs.api.ProgramWorkflowService;
 import org.openmrs.api.context.Context;
 import org.openmrs.util.OpenmrsUtil;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 public class DWRProgramWorkflowService {
 	
@@ -36,10 +38,12 @@ public class DWRProgramWorkflowService {
 	
 	DateFormat ymdDf = new SimpleDateFormat("yyyy-MM-dd");
 	
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_PROGRAMS)
 	public PatientProgramItem getPatientProgram(Integer patientProgramId) {
 		return new PatientProgramItem(Context.getProgramWorkflowService().getPatientProgram(patientProgramId));
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_PROGRAMS)
 	public Vector<ListItem> getPossibleOutcomes(Integer programId) {
 		Vector<ListItem> ret = new Vector<ListItem>();
 		List<Concept> possibleOutcomes = Context.getProgramWorkflowService().getPossibleOutcomes(programId);
@@ -52,6 +56,7 @@ public class DWRProgramWorkflowService {
 		return ret;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_PROGRAMS)
 	public Vector<PatientStateItem> getPatientStates(Integer patientProgramId, Integer programWorkflowId) {
 		Vector<PatientStateItem> ret = new Vector<PatientStateItem>();
 		ProgramWorkflowService s = Context.getProgramWorkflowService();
@@ -63,6 +68,7 @@ public class DWRProgramWorkflowService {
 		return ret;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_PROGRAMS)
 	public Vector<ListItem> getWorkflowsByProgram(Integer programId) {
 		Vector<ListItem> ret = new Vector<ListItem>();
 		Program program = Context.getProgramWorkflowService().getProgram(programId);
@@ -122,6 +128,7 @@ public class DWRProgramWorkflowService {
 		return workflow;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_PROGRAMS)
 	public Vector<ListItem> getStatesByWorkflow(String workflowLookup) {
 		log.debug("In getStatesByWorkflow with workflow uuid of " + workflowLookup);
 		Vector<ListItem> ret = new Vector<ListItem>();
@@ -173,6 +180,7 @@ public class DWRProgramWorkflowService {
 	 * @param outcomeId
 	 * @throws ParseException
 	 */
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENT_PROGRAMS)
 	public void updatePatientProgram(Integer patientProgramId, String enrollmentDateYmd, String completionDateYmd,
 	        Integer locationId, Integer outcomeId) throws ParseException {
 		PatientProgram pp = Context.getProgramWorkflowService().getPatientProgram(patientProgramId);
@@ -230,6 +238,7 @@ public class DWRProgramWorkflowService {
 		}
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENT_PROGRAMS)
 	public void deletePatientProgram(Integer patientProgramId, String reason) {
 		PatientProgram p = Context.getProgramWorkflowService().getPatientProgram(patientProgramId);
 		Context.getProgramWorkflowService().voidPatientProgram(p, reason);
@@ -238,6 +247,7 @@ public class DWRProgramWorkflowService {
 	/**
 	 * @should return a list consisting of active, not retired, states.
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_PROGRAMS)
 	public Vector<ListItem> getPossibleNextStates(Integer patientProgramId, Integer programWorkflowId) {
 		Vector<ListItem> ret = new Vector<ListItem>();
 		PatientProgram pp = Context.getProgramWorkflowService().getPatientProgram(patientProgramId);
@@ -256,6 +266,7 @@ public class DWRProgramWorkflowService {
 	
 	//TODO there doesn't seem to be any way in the administrator interface to retire a state, just a concept.
 	
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENT_PROGRAMS)
 	public void changeToState(Integer patientProgramId, Integer programWorkflowId, Integer programWorkflowStateId,
 	        String onDateDMY) throws ParseException {
 		ProgramWorkflowService s = Context.getProgramWorkflowService();
@@ -269,6 +280,7 @@ public class DWRProgramWorkflowService {
 		s.savePatientProgram(pp);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.EDIT_PATIENT_PROGRAMS)
 	public void voidLastState(Integer patientProgramId, Integer programWorkflowId, String voidReason) {
 		ProgramWorkflowService s = Context.getProgramWorkflowService();
 		PatientProgram pp = s.getPatientProgram(patientProgramId);

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRProgramWorkflowService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRProgramWorkflowService.java
@@ -245,7 +245,8 @@ public class DWRProgramWorkflowService {
 	}
 	
 	/**
-	 * @should return a list consisting of active, not retired, states.
+	 * <p>
+	 * <b>Should</b> return a list consisting of active, not retired, states.
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PATIENT_PROGRAMS)
 	public Vector<ListItem> getPossibleNextStates(Integer patientProgramId, Integer programWorkflowId) {

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRProviderService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRProviderService.java
@@ -21,7 +21,9 @@ import org.openmrs.api.APIException;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebUtil;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * DWR Provider methods. The methods in here are used in the webapp to get data from the database
@@ -46,6 +48,7 @@ public class DWRProviderService {
 	 * @should return the list of providers matching the search name
 	 * @should return the list of providers including retired providers for the matching search name
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PROVIDERS)
 	public Vector<Object> findProvider(String name, boolean includeRetired, Integer start, Integer length) {
 		Vector<Object> providerListItem = new Vector<Object>();
 		List<Provider> providerList = Context.getProviderService().getProviders(name, start, length, null, includeRetired);
@@ -74,6 +77,7 @@ public class DWRProviderService {
 	 * @should return the count of all providers matching the searched name along with provider list
 	 *         for given length
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PROVIDERS)
 	public Map<String, Object> findProviderCountAndProvider(String name, boolean includeRetired, Integer start,
 	        Integer length) throws APIException {
 		Map<String, Object> providerMap = new HashMap<String, Object>();
@@ -98,6 +102,7 @@ public class DWRProviderService {
 	 * @param providerId
 	 * @return provider
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_PROVIDERS)
 	public ProviderListItem getProvider(Integer providerId) {
 		return new ProviderListItem(Context.getProviderService().getProvider(providerId));
 	}

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRProviderService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRProviderService.java
@@ -38,15 +38,17 @@ public class DWRProviderService {
 	
 	/**
 	 * Finds providers
+	 * <p>
+	 * <b>Should</b> return a message with no matches found when no providers are found.<br>
+	 * <b>Should</b> return the list of providers matching the search name.<br>
+	 * <b>Should</b> return the list of providers including retired providers for the matching
+	 * search name.
 	 * 
 	 * @param name to search
 	 * @param includeRetired true/false whether or not to included retired providers
 	 * @param start starting index for the results to return
 	 * @param length the number of results to return
 	 * @return a list of matching providers
-	 * @should return a message with no matches found when no providers are found
-	 * @should return the list of providers matching the search name
-	 * @should return the list of providers including retired providers for the matching search name
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PROVIDERS)
 	public Vector<Object> findProvider(String name, boolean includeRetired, Integer start, Integer length) {
@@ -67,6 +69,9 @@ public class DWRProviderService {
 	
 	/**
 	 * Finds providers for the given name along with the total count of providers that matched.
+	 * <p>
+	 * <b>Should</b> return the count of all providers matching the searched name along with
+	 * provider list for given length.
 	 * 
 	 * @param name to search
 	 * @param includeRetired true/false whether or not to included retired providers
@@ -74,8 +79,6 @@ public class DWRProviderService {
 	 * @param length the number of results to return
 	 * @return a list of matching providers
 	 * @throws APIException on any errors while searching providers
-	 * @should return the count of all providers matching the searched name along with provider list
-	 *         for given length
 	 */
 	@RequirePrivilege(PrivilegeConstants.GET_PROVIDERS)
 	public Map<String, Object> findProviderCountAndProvider(String name, boolean includeRetired, Integer start,

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRRelationshipService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRRelationshipService.java
@@ -23,13 +23,16 @@ import org.openmrs.Relationship;
 import org.openmrs.RelationshipType;
 import org.openmrs.api.PersonService;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.validator.RelationshipValidator;
+import org.openmrs.web.security.RequirePrivilege;
 import org.springframework.validation.MapBindingResult;
 
 public class DWRRelationshipService {
 	
 	protected final Log log = LogFactory.getLog(getClass());
 	
+	@RequirePrivilege(PrivilegeConstants.ADD_RELATIONSHIPS)
 	public String[] createRelationship(Integer personAId, Integer personBId, Integer relationshipTypeId, String startDateStr)
 	        throws Exception {
 		PersonService ps = Context.getPersonService();
@@ -56,10 +59,12 @@ public class DWRRelationshipService {
 		return errmsgs;
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.EDIT_RELATIONSHIPS)
 	public void voidRelationship(Integer relationshipId, String voidReason) {
 		Context.getPersonService().voidRelationship(Context.getPersonService().getRelationship(relationshipId), voidReason);
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.EDIT_RELATIONSHIPS)
 	public boolean changeRelationshipDates(Integer relationshipId, String startDateStr, String endDateStr) throws Exception {
 		Relationship r = Context.getPersonService().getRelationship(relationshipId);
 		Date startDate = null;
@@ -83,6 +88,7 @@ public class DWRRelationshipService {
 		}
 	}
 	
+	@RequirePrivilege(PrivilegeConstants.GET_RELATIONSHIPS)
 	public Vector<RelationshipListItem> getRelationships(Integer personId, Integer relationshipTypeId) {
 		// hack to make sure other relationships aren't still hanging around
 		Context.clearSession();

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRUserService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRUserService.java
@@ -25,7 +25,9 @@ import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
+import org.openmrs.util.PrivilegeConstants;
 import org.openmrs.web.WebUtil;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * A collection of methods used by DWR for access users. These methods are similar to the
@@ -46,6 +48,7 @@ public class DWRUserService {
 	 * @return list of {@link UserListItem}s (or String warning message if none found)
 	 */
 	@SuppressWarnings("unchecked")
+	@RequirePrivilege(PrivilegeConstants.GET_USERS)
 	public Collection<UserListItem> findUsers(String searchValue, List<String> rolesStrings, boolean includeVoided) {
 		
 		Vector userList = new Vector();
@@ -87,6 +90,7 @@ public class DWRUserService {
 	}
 	
 	@SuppressWarnings("unchecked")
+	@RequirePrivilege(PrivilegeConstants.GET_USERS)
 	public Collection<UserListItem> getAllUsers(List<String> roleStrings, boolean includeVoided) {
 		
 		Vector userList = new Vector();
@@ -141,6 +145,7 @@ public class DWRUserService {
 	 * @param userId
 	 * @return found user item or, if the current user is not authenticated, a dummy user object
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_USERS)
 	public UserListItem getUser(Integer userId) {
 		UserListItem user = new UserListItem();
 		

--- a/omod/src/main/java/org/openmrs/web/dwr/DWRVisitService.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/DWRVisitService.java
@@ -20,6 +20,8 @@ import org.openmrs.Visit;
 import org.openmrs.api.APIException;
 import org.openmrs.api.context.Context;
 import org.openmrs.messagesource.MessageSourceService;
+import org.openmrs.util.PrivilegeConstants;
+import org.openmrs.web.security.RequirePrivilege;
 
 /**
  * Contains methods for processing DWR requests for visits
@@ -40,6 +42,7 @@ public class DWRVisitService {
 	 * @see VisitListItem
 	 * @throws APIException
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_VISITS)
 	public Vector<Object> findVisitsByPatient(Integer patientId, boolean includeInactive, boolean includeVoided)
 	        throws APIException {
 		// List to return
@@ -79,6 +82,7 @@ public class DWRVisitService {
 	 * @return the {@link VisitListItem} for the matching visit
 	 * @throws APIException
 	 */
+	@RequirePrivilege(PrivilegeConstants.GET_VISITS)
 	public VisitListItem getVisit(Integer visitId) throws APIException {
 		Visit v = Context.getVisitService().getVisit(visitId);
 		return v == null ? null : new VisitListItem(v);
@@ -91,6 +95,7 @@ public class DWRVisitService {
 	 * @return list of encounters
 	 * @throws APIException
 	 */
+	@RequirePrivilege(value = { PrivilegeConstants.GET_VISITS, PrivilegeConstants.GET_ENCOUNTERS }, requireAll = true)
 	public Vector<Object> findEncountersByVisit(Integer visitId) throws APIException {
 		// List to return
 		Vector<Object> objectList = new Vector<Object>();

--- a/omod/src/main/java/org/openmrs/web/dwr/PersonListItem.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/PersonListItem.java
@@ -72,11 +72,12 @@ public class PersonListItem {
 	 * Creates an instance of a subclass of PersonListItem which is best suited for the parameter.
 	 * If a {@link Patient} is passed in, a {@link PatientListItem} is returned, otherwise a
 	 * {@link PersonListItem} is returned.
+	 * <p>
+	 * <b>Should</b> return PatientListItem given patient parameter.<br>
+	 * <b>Should</b> return PersonListItem given person parameter.
 	 * 
 	 * @param person the {@link Person} object to covert to a {@link PersonListItem}
 	 * @return a {@link PersonListItem} or subclass thereof
-	 * @should return PatientListItem given patient parameter
-	 * @should return PersonListItem given person parameter
 	 */
 	public static PersonListItem createBestMatch(Person person) {
 		if (person instanceof Patient) {
@@ -104,9 +105,10 @@ public class PersonListItem {
 	/**
 	 * Convenience constructor that creates a PersonListItem from the given Person. All relevant
 	 * attributes are pulled off of the Person object and copied to this PersonListItem
+	 * <p>
+	 * <b>Should</b> put attribute toString value into attributes map.
 	 * 
 	 * @param person the Person to turn into a PersonListItem
-	 * @should put attribute toString value into attributes map
 	 */
 	public PersonListItem(Person person) {
 		
@@ -155,14 +157,15 @@ public class PersonListItem {
 	 * Convenience constructor that creates a PersonListItem from the given Person. All relevant
 	 * attributes are pulled off of the Person object and copied to this PersonListItem. And set the
 	 * best match name based on the search criteria.
+	 * <p>
+	 * <b>Should</b> identify best matching name for the family name.<br>
+	 * <b>Should</b> identify best matching name as preferred name even if other names match.<br>
+	 * <b>Should</b> identify best matching name as other name for the middle name.<br>
+	 * <b>Should</b> identify best matching name as other name for the given name.<br>
+	 * <b>Should</b> identify best matching name in multiple search names.
 	 * 
 	 * @param person the Person to turn into a PersonListItem
 	 * @param searchName Search query string of the name
-	 * @should identify best matching name for the family name
-	 * @should identify best matching name as preferred name even if other names match
-	 * @should identify best matching name as other name for the middle name
-	 * @should identify best matching name as other name for the given name
-	 * @should identify best matching name in multiple search names
 	 */
 	public PersonListItem(Person person, String searchName) {
 		this(person);
@@ -191,11 +194,12 @@ public class PersonListItem {
 	/**
 	 * Helper method to check if all the search names(separated by spaces) are contained in the
 	 * person's full name.
+	 * <p>
+	 * <b>Should</b> return true when all searched names are found in full name.<br>
+	 * <b>Should</b> return false if even one of the searched names are not found in full name.
 	 * 
 	 * @param fullName the fullName upon which the search names are to be compared
 	 * @param searchNames Array&lt;String&gt; of searched names
-	 * @should return true when all searched names are found in full name
-	 * @should return false if even one of the searched names are not found in full name
 	 */
 	private boolean containsAll(String fullName, String[] searchNames) {
 		for (String name : searchNames) {

--- a/omod/src/main/java/org/openmrs/web/dwr/ProviderListItem.java
+++ b/omod/src/main/java/org/openmrs/web/dwr/ProviderListItem.java
@@ -44,25 +44,31 @@ public class ProviderListItem {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> return the identifier that is mentioned for the provider when a person is not
+	 * specified.
+	 * 
 	 * @return the identifier of the provider
-	 * @should return the identifier that is mentioned for the provider when a person is not
-	 *         specified
 	 */
 	public String getIdentifier() {
 		return identifier;
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> return a display name based on whether provider has a person associated.
+	 * 
 	 * @return the display name for the provider
-	 * @should return a display name based on whether provider has a person associated
 	 */
 	public String getDisplayName() {
 		return displayName;
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> return the provider id.
+	 * 
 	 * @return the provider id
-	 * @should return the provider id
 	 */
 	public Integer getProviderId() {
 		return providerId;

--- a/omod/src/main/java/org/openmrs/web/form/visit/ConfigureVisitsForm.java
+++ b/omod/src/main/java/org/openmrs/web/form/visit/ConfigureVisitsForm.java
@@ -15,7 +15,7 @@ import java.util.List;
 import org.openmrs.VisitType;
 
 /**
- * Form used by {@link ConfigureVisitsFormController}.
+ * Form used by {@link org.openmrs.web.controller.visit.ConfigureVisitsFormController}.
  */
 public class ConfigureVisitsForm {
 	

--- a/omod/src/main/java/org/openmrs/web/security/AuthorizationHandlerInterceptor.java
+++ b/omod/src/main/java/org/openmrs/web/security/AuthorizationHandlerInterceptor.java
@@ -1,0 +1,175 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.openmrs.web.WebConstants;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Spring {@link HandlerInterceptor} that enforces {@link RequirePrivilege} declarations on handler
+ * classes and methods before any controller code runs. The check happens in
+ * {@link #preHandle(HttpServletRequest, HttpServletResponse, Object)}, which Spring invokes after
+ * URL resolution but before {@code formBackingObject}, {@code @ModelAttribute} methods, or any
+ * data binding. Rejecting the request here means no Hibernate entity is loaded for the attacker's
+ * payload to bind onto, which closes the dirty-entity bypass that service-layer
+ * {@code @Authorized} alone cannot defend against.
+ * <p>
+ * Behaviour mirrors {@code org.openmrs.web.taglib.RequireTag}:
+ * <ul>
+ * <li>An unauthenticated caller is redirected to {@code /login.htm} with the original URL stashed
+ * in {@link WebConstants#OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR} so the post-login redirect
+ * returns them to where they were going.</li>
+ * <li>An authenticated caller missing the required privilege gets the same redirect, plus the
+ * standard privilege-related session attributes ({@link WebConstants#INSUFFICIENT_PRIVILEGES},
+ * {@link WebConstants#REQUIRED_PRIVILEGES}, {@link WebConstants#DENIED_PAGE}) so existing
+ * downstream UX (eg. the access-denied page) keeps working unchanged.</li>
+ * </ul>
+ * <p>
+ * Resolution rules for the annotation:
+ * <ol>
+ * <li>If the handler is a {@link HandlerMethod} (annotation-driven controller), look at the method
+ * first, then fall back to the declaring class.</li>
+ * <li>Otherwise (legacy {@code SimpleFormController}-style bean), look at the class.</li>
+ * <li>If no annotation is present, the interceptor allows the request through (fail-open).
+ * Annotations are being rolled out incrementally; unannotated handlers retain pre-rollout
+ * behaviour.</li>
+ * </ol>
+ */
+public class AuthorizationHandlerInterceptor implements HandlerInterceptor {
+
+	private final Log log = LogFactory.getLog(getClass());
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+
+		RequirePrivilege annotation = resolveAnnotation(handler);
+		if (annotation == null) {
+			return true;
+		}
+
+		UserContext userContext = Context.getUserContext();
+		if (userContext == null) {
+			log.error("UserContext is null; OpenmrsFilter must run before this interceptor");
+			return denyUnauthenticated(request, response);
+		}
+
+		if (!userContext.isAuthenticated()) {
+			return denyUnauthenticated(request, response);
+		}
+
+		List<String> missing = missingPrivileges(userContext, annotation);
+		if (missing.isEmpty()) {
+			return true;
+		}
+
+		return denyInsufficientPrivilege(request, response, missing);
+	}
+
+	private RequirePrivilege resolveAnnotation(Object handler) {
+		if (handler instanceof HandlerMethod) {
+			HandlerMethod hm = (HandlerMethod) handler;
+			RequirePrivilege onMethod = AnnotationUtils.findAnnotation(hm.getMethod(), RequirePrivilege.class);
+			if (onMethod != null) {
+				return onMethod;
+			}
+			return AnnotationUtils.findAnnotation(hm.getBeanType(), RequirePrivilege.class);
+		}
+		if (handler == null) {
+			return null;
+		}
+		return AnnotationUtils.findAnnotation(handler.getClass(), RequirePrivilege.class);
+	}
+
+	private List<String> missingPrivileges(UserContext userContext, RequirePrivilege annotation) {
+		String[] privileges = annotation.value();
+		if (privileges.length == 0) {
+			// the annotation requires authentication only; we already verified that
+			return new ArrayList<>();
+		}
+
+		List<String> missing = new ArrayList<>();
+		if (annotation.requireAll()) {
+			for (String privilege : privileges) {
+				String trimmed = privilege.trim();
+				if (!trimmed.isEmpty() && !userContext.hasPrivilege(trimmed)) {
+					missing.add(trimmed);
+				}
+			}
+			return missing;
+		}
+
+		// any-of: pass if the user holds at least one
+		for (String privilege : privileges) {
+			String trimmed = privilege.trim();
+			if (!trimmed.isEmpty() && userContext.hasPrivilege(trimmed)) {
+				return new ArrayList<>();
+			}
+		}
+		// none matched - report the full set as missing for the diagnostic page
+		for (String privilege : privileges) {
+			String trimmed = privilege.trim();
+			if (!trimmed.isEmpty()) {
+				missing.add(trimmed);
+			}
+		}
+		return missing;
+	}
+
+	private boolean denyUnauthenticated(HttpServletRequest request, HttpServletResponse response) throws IOException {
+		HttpSession session = request.getSession();
+		session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "require.login");
+		stashLoginRedirect(request, session);
+		response.sendRedirect(request.getContextPath() + "/login.htm");
+		return false;
+	}
+
+	private boolean denyInsufficientPrivilege(HttpServletRequest request, HttpServletResponse response,
+	        List<String> missing) throws IOException {
+		HttpSession session = request.getSession();
+		session.setAttribute(WebConstants.INSUFFICIENT_PRIVILEGES, true);
+		session.setAttribute(WebConstants.REQUIRED_PRIVILEGES, String.join(",", missing));
+
+		String referer = request.getHeader("Referer");
+		if (referer != null && !referer.isEmpty()) {
+			session.setAttribute(WebConstants.REFERER_URL, referer);
+			session.setAttribute(WebConstants.DENIED_PAGE, referer);
+		}
+
+		log.warn("User '" + Context.getAuthenticatedUser() + "' attempted to access "
+		        + request.getRequestURI() + " without required privilege(s): " + missing);
+
+		stashLoginRedirect(request, session);
+		response.sendRedirect(request.getContextPath() + "/login.htm");
+		return false;
+	}
+
+	private void stashLoginRedirect(HttpServletRequest request, HttpSession session) {
+		String url = request.getRequestURI();
+		if (request.getQueryString() != null) {
+			url = url + "?" + request.getQueryString();
+		}
+		session.setAttribute(WebConstants.OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR, url);
+	}
+
+}

--- a/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
+++ b/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.web.security;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -20,6 +21,7 @@ import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -30,36 +32,56 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
+import org.openmrs.util.OpenmrsClassLoader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
- * Servlet filter that enforces {@link RequirePrivilege} on every DWR method invocation served by
- * the legacyui module. DWR has its own request pipeline ({@code /dwr/*},
- * {@code /ms/call/plaincall/*}) outside Spring's {@code DispatcherServlet}, so
- * {@link AuthorizationHandlerInterceptor} does not see these calls. This filter is the
- * request-boundary check for that pipeline.
+ * Servlet filter that enforces {@link RequirePrivilege}, where it's actually declared, on DWR
+ * method invocations. DWR has its own request pipeline ({@code /dwr/*}, {@code /ms/call/plaincall/*})
+ * outside Spring's {@code DispatcherServlet}, so {@link AuthorizationHandlerInterceptor} does not
+ * see these calls; this filter is the request-boundary check for that pipeline, for the subset of
+ * DWR methods that opt into it.
  * <p>
- * At {@link #init(FilterConfig)} the filter parses {@code config.xml} from the classpath, walks
- * every {@code <create>}/{@code <include method="...">} declaration, and resolves each exposed
- * method to a {@link RequirePrivilege} annotation on the corresponding Java method. Methods
- * without an annotation are rejected at request time with {@code 403 Forbidden}; a warning is
- * logged at startup so any new DWR endpoint that ships without an annotation is visible.
+ * {@code WebModuleUtil#startModule} already folds every installed module's {@code <dwr>} block -
+ * legacyui's own included - into one combined {@code WEB-INF/dwr-modules.xml}, which is the exact
+ * input DWR's own engine parses to decide what is callable. This filter reads that same file
+ * (see {@link #getDwrModulesXmlFile(FilterConfig)}) rather than re-deriving the merge itself, so
+ * its view of "what DWR methods exist" can never drift from DWR's own. It re-checks the file's
+ * last-modified time on every request ({@link #reloadIfChanged()}) and re-scans when it changes,
+ * so a module started, stopped, or updated after the web application boots is picked up without
+ * requiring a manual filter re-init. Each {@code <create>}/{@code <include method="...">}
+ * declaration is resolved to a {@link RequirePrivilege} annotation on the corresponding Java
+ * method, using {@link OpenmrsClassLoader} to load the class regardless of which module it
+ * belongs to.
+ * <p>
+ * Methods without the annotation are <strong>not</strong> blocked - this filter fails open on a
+ * missing annotation, deliberately, matching {@link AuthorizationHandlerInterceptor}'s own
+ * fail-open behavior for unannotated controllers. Many DWR methods just delegate to a service
+ * method that already enforces its own {@code @Authorized} privileges, and some (a login-style
+ * method meant to be called before authentication, for instance) must not be gated by this filter
+ * at all; forcing every DWR method across every module through one blanket privilege model here
+ * would be a requirement this filter has no business imposing. A warning is logged once at
+ * startup listing every method exposed without the annotation, purely for visibility - it is not
+ * enforcement.
+ * <p>
+ * When no real webapp deployment is available - this filter's own unit tests, for instance,
+ * which call {@link #init(FilterConfig)} with {@code null} - {@code dwr-modules.xml} can't be
+ * located. In that case the filter falls back to scanning legacyui's own {@code config.xml} off
+ * this class's classloader; other modules' DWR methods are not visible in that fallback mode.
  * <p>
  * For each request:
  * <ol>
  * <li>If the URL is not a DWR method call (e.g. {@code /dwr/engine.js},
  * {@code /dwr/interface/Foo.js}), pass it through unchanged.</li>
- * <li>If the URL is a method call, require authentication. Unauthenticated requests get
- * {@code 401 Unauthorized}.</li>
- * <li>Look up {@code {Script}.{method}}; if no annotation is registered (either because the
- * pair is unknown or because the method is exposed in {@code config.xml} without
- * {@link RequirePrivilege}), reject with {@code 403 Forbidden}.</li>
+ * <li>Look up {@code {Script}.{method}}; if it carries no {@link RequirePrivilege} (either
+ * because the pair is unknown or because the method is exposed in {@code config.xml} without
+ * the annotation), pass it through unchanged - see above.</li>
+ * <li>Otherwise require authentication. Unauthenticated requests get {@code 401 Unauthorized}.</li>
  * <li>Enforce the annotation's privilege list. Missing privileges yield {@code 403 Forbidden}.</li>
  * </ol>
  * <p>
@@ -81,26 +103,142 @@ public class DwrAuthorizationFilter implements Filter {
 
 	private Map<String, String> unannotatedMethods = Collections.emptyMap();
 
+	/**
+	 * The aggregated DWR config file to watch, resolved once at {@link #init(FilterConfig)}.
+	 * {@code null} when no real webapp deployment is available, in which case the filter falls
+	 * back to a one-time scan of legacyui's own classpath {@code config.xml}.
+	 */
+	private File dwrModulesXmlFile;
+
+	private volatile long dwrModulesXmlLastModified = -1;
+
+	/** Guards {@link #fallbackLoaded} so the classpath fallback only ever runs once. */
+	private final Object reloadLock = new Object();
+
+	private boolean fallbackLoaded = false;
+
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
 		try {
-			Map<String, RequirePrivilege> annotated = new HashMap<>();
-			Map<String, String> unannotated = new LinkedHashMap<>();
-			loadDwrAnnotations(annotated, unannotated);
-			this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
-			this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
-
-			log.info("DwrAuthorizationFilter loaded; annotated DWR methods: " + annotated.size()
-			        + ", unannotated (will be rejected with 403): " + unannotated.size());
-			if (!unannotated.isEmpty()) {
-				log.warn("The following DWR methods are exposed in config.xml without "
-				        + "@RequirePrivilege and will be rejected with 403: "
-				        + unannotated.keySet());
-			}
+			this.dwrModulesXmlFile = getDwrModulesXmlFile(filterConfig);
+			reloadIfChanged();
 		}
 		catch (Exception e) {
 			throw new ServletException("Failed to initialize DwrAuthorizationFilter", e);
 		}
+	}
+
+	/**
+	 * Resolves the {@code WEB-INF/dwr-modules.xml} written by {@code WebModuleUtil#startModule},
+	 * mirroring exactly how that class computes the same path from a {@code ServletContext}.
+	 * Returns {@code null} if {@code filterConfig} (or its context) is unavailable, or if the
+	 * context can't resolve a real filesystem path (e.g. an unexploded/embedded deployment).
+	 */
+	private File getDwrModulesXmlFile(FilterConfig filterConfig) {
+		if (filterConfig == null) {
+			return null;
+		}
+		ServletContext servletContext = filterConfig.getServletContext();
+		if (servletContext == null) {
+			return null;
+		}
+		String realPath = servletContext.getRealPath("/WEB-INF/dwr-modules.xml");
+		return realPath == null ? null : new File(realPath);
+	}
+
+	/**
+	 * Re-scans {@link #dwrModulesXmlFile} if its last-modified time has changed since the last
+	 * scan (including the very first one), so a module started, stopped, or updated after boot
+	 * is reflected without requiring this filter to be re-initialized. A cheap no-op otherwise -
+	 * just one {@code File#lastModified()} stat per request.
+	 */
+	private void reloadIfChanged() throws Exception {
+		if (dwrModulesXmlFile == null || !dwrModulesXmlFile.exists()) {
+			loadFallbackOnce();
+			return;
+		}
+
+		long modified = dwrModulesXmlFile.lastModified();
+		if (modified == dwrModulesXmlLastModified) {
+			return;
+		}
+
+		synchronized (reloadLock) {
+			if (modified == dwrModulesXmlLastModified) {
+				return; // another thread already reloaded while we were waiting
+			}
+
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+
+			DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
+			Document doc = dbf.newDocumentBuilder().parse(dwrModulesXmlFile);
+			scanDwrCreates(doc, OpenmrsClassLoader.getInstance(), annotated, unannotated);
+
+			applyLoadedAnnotations(annotated, unannotated);
+			dwrModulesXmlLastModified = modified;
+		}
+	}
+
+	/**
+	 * Fallback for contexts with no real servlet deployment, e.g. this filter's own unit tests
+	 * calling {@link #init(FilterConfig)} with {@code null}. Scans legacyui's own
+	 * {@code config.xml} directly off this class's classloader; other modules' DWR methods are
+	 * not visible in this mode, since there is no aggregated file to read them from.
+	 */
+	private void loadFallbackOnce() throws Exception {
+		synchronized (reloadLock) {
+			if (fallbackLoaded) {
+				return;
+			}
+
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+
+			ClassLoader ownClassLoader = getClass().getClassLoader();
+			try (InputStream in = ownClassLoader.getResourceAsStream("config.xml")) {
+				if (in == null) {
+					log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow no DWR calls");
+				} else {
+					DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
+					Document doc = dbf.newDocumentBuilder().parse(in);
+					scanDwrCreates(doc, ownClassLoader, annotated, unannotated);
+				}
+			}
+
+			applyLoadedAnnotations(annotated, unannotated);
+			fallbackLoaded = true;
+		}
+	}
+
+	private void applyLoadedAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated) {
+		this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
+		this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
+
+		log.info("DwrAuthorizationFilter (re)loaded; annotated DWR methods: " + annotated.size()
+		        + ", unannotated (will be rejected with 403): " + unannotated.size());
+		if (!unannotated.isEmpty()) {
+			log.warn("The following DWR methods are exposed without @RequirePrivilege and will be "
+			        + "rejected with 403: " + unannotated.keySet());
+		}
+	}
+
+	/**
+	 * {@code dwr-modules.xml} legitimately declares a DOCTYPE referencing DWR's own public DTD
+	 * (e.g. {@code <!DOCTYPE dwr PUBLIC "-//GetAhead Limited//DTD Direct Web Remoting 2.0//EN"
+	 * "http://directwebremoting.org/schema/dwr20.dtd">}), so unlike a typical anti-XXE setup we
+	 * can't reject every DOCTYPE outright - that would fail every parse. Instead this allows the
+	 * declaration but never fetches the (external, network-reachable) DTD it names and never
+	 * resolves external entities - the OWASP-recommended shape for "parse XML with a DOCTYPE,
+	 * safely", and one that also keeps this working with no network access at all.
+	 */
+	private DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setNamespaceAware(false);
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		return dbf;
 	}
 
 	@Override
@@ -116,25 +254,34 @@ public class DwrAuthorizationFilter implements Filter {
 			return;
 		}
 
-		UserContext userContext = Context.getUserContext();
-		if (userContext == null || !userContext.isAuthenticated()) {
-			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
-			    "Authentication required to invoke " + scriptMethod);
-			return;
+		try {
+			reloadIfChanged();
+		}
+		catch (Exception e) {
+			// Keep serving whatever was last successfully loaded rather than failing every
+			// request; a transient read/parse error here shouldn't take down all of DWR.
+			log.error("Failed to (re)load DWR authorization config; continuing with the previous snapshot", e);
 		}
 
 		RequirePrivilege annotation = privilegesByScriptMethod.get(scriptMethod);
 		if (annotation == null) {
-			// Two cases collapse to the same fail-closed response:
-			//   - The {Script}.{method} is declared in config.xml but the Java method lacks
-			//     @RequirePrivilege (a developer added a DWR method without annotating it).
-			//   - The {Script}.{method} pair is not declared in config.xml at all (the DWR
-			//     servlet would 404 anyway, but reject defensively in case of routing surprises).
-			if (unannotatedMethods.containsKey(scriptMethod)) {
-				log.warn("DWR method " + scriptMethod
-				        + " is declared in config.xml but has no @RequirePrivilege; rejecting");
-			}
-			deny(httpResponse, HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+			// No @RequirePrivilege on this method - either it's declared in config.xml without
+			// the annotation, or the {Script}.{method} pair isn't declared anywhere we scanned.
+			// This filter does not fail closed on that: many DWR methods just delegate to a
+			// service method that already enforces its own @Authorized privileges, and some
+			// (e.g. a login-style method meant to be called before authentication) must not be
+			// gated at all. Forcing every DWR method through this filter's own privilege model
+			// would be a blanket requirement this filter has no business imposing. Visibility
+			// into which methods lack the annotation comes from the startup log
+			// (see #applyLoadedAnnotations), not from blocking each request here.
+			chain.doFilter(request, response);
+			return;
+		}
+
+		UserContext userContext = Context.getUserContext();
+		if (userContext == null || !userContext.isAuthenticated()) {
+			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
+			    "Authentication required to invoke " + scriptMethod);
 			return;
 		}
 
@@ -222,61 +369,44 @@ public class DwrAuthorizationFilter implements Filter {
 	}
 
 	/**
-	 * Parses {@code config.xml} from the legacyui classpath and resolves each declared DWR
-	 * method to its {@link RequirePrivilege} annotation. Methods without the annotation are
-	 * collected separately so the filter can warn at startup rather than fail outright while
-	 * the rollout is in progress.
+	 * Walks every {@code <create>}/{@code <include method="...">} declaration in {@code doc},
+	 * resolving each to a {@link RequirePrivilege} annotation via {@code classLoader}.
 	 */
-	private void loadDwrAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated)
-	        throws Exception {
-		ClassLoader classLoader = getClass().getClassLoader();
-		try (InputStream in = classLoader.getResourceAsStream("config.xml")) {
-			if (in == null) {
-				log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow all DWR calls");
-				return;
+	private void scanDwrCreates(Document doc, ClassLoader classLoader, Map<String, RequirePrivilege> annotated,
+	        Map<String, String> unannotated) {
+		NodeList creates = doc.getElementsByTagName("create");
+		for (int i = 0; i < creates.getLength(); i++) {
+			Element create = (Element) creates.item(i);
+			String script = create.getAttribute("javascript");
+			if (script == null || script.isEmpty()) {
+				continue;
 			}
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(false);
-			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-			DocumentBuilder builder = dbf.newDocumentBuilder();
-			Document doc = builder.parse(in);
-
-			NodeList creates = doc.getElementsByTagName("create");
-			for (int i = 0; i < creates.getLength(); i++) {
-				Element create = (Element) creates.item(i);
-				String script = create.getAttribute("javascript");
-				if (script == null || script.isEmpty()) {
+			String className = findClassParam(create);
+			if (className == null) {
+				log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
+				continue;
+			}
+			Class<?> dwrClass;
+			try {
+				dwrClass = Class.forName(className, false, classLoader);
+			}
+			catch (ClassNotFoundException e) {
+				log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
+				continue;
+			}
+			NodeList includes = create.getElementsByTagName("include");
+			for (int j = 0; j < includes.getLength(); j++) {
+				Element include = (Element) includes.item(j);
+				String methodName = include.getAttribute("method");
+				if (methodName == null || methodName.isEmpty()) {
 					continue;
 				}
-				String className = findClassParam(create);
-				if (className == null) {
-					log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
-					continue;
-				}
-				Class<?> dwrClass;
-				try {
-					dwrClass = Class.forName(className, false, classLoader);
-				}
-				catch (ClassNotFoundException e) {
-					log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
-					continue;
-				}
-				NodeList includes = create.getElementsByTagName("include");
-				for (int j = 0; j < includes.getLength(); j++) {
-					Element include = (Element) includes.item(j);
-					String methodName = include.getAttribute("method");
-					if (methodName == null || methodName.isEmpty()) {
-						continue;
-					}
-					String key = script + "." + methodName;
-					RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
-					if (annotation != null) {
-						annotated.put(key, annotation);
-					} else {
-						unannotated.put(key, className + "#" + methodName);
-					}
+				String key = script + "." + methodName;
+				RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
+				if (annotation != null) {
+					annotated.put(key, annotation);
+				} else {
+					unannotated.put(key, className + "#" + methodName);
 				}
 			}
 		}

--- a/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
+++ b/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
@@ -1,0 +1,334 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.UserContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+/**
+ * Servlet filter that enforces {@link RequirePrivilege} on every DWR method invocation served by
+ * the legacyui module. DWR has its own request pipeline ({@code /dwr/*},
+ * {@code /ms/call/plaincall/*}) outside Spring's {@code DispatcherServlet}, so
+ * {@link AuthorizationHandlerInterceptor} does not see these calls. This filter is the
+ * request-boundary check for that pipeline.
+ * <p>
+ * At {@link #init(FilterConfig)} the filter parses {@code config.xml} from the classpath, walks
+ * every {@code <create>}/{@code <include method="...">} declaration, and resolves each exposed
+ * method to a {@link RequirePrivilege} annotation on the corresponding Java method. Methods
+ * without an annotation are rejected at request time with {@code 403 Forbidden}; a warning is
+ * logged at startup so any new DWR endpoint that ships without an annotation is visible.
+ * <p>
+ * For each request:
+ * <ol>
+ * <li>If the URL is not a DWR method call (e.g. {@code /dwr/engine.js},
+ * {@code /dwr/interface/Foo.js}), pass it through unchanged.</li>
+ * <li>If the URL is a method call, require authentication. Unauthenticated requests get
+ * {@code 401 Unauthorized}.</li>
+ * <li>Look up {@code {Script}.{method}}; if no annotation is registered (either because the
+ * pair is unknown or because the method is exposed in {@code config.xml} without
+ * {@link RequirePrivilege}), reject with {@code 403 Forbidden}.</li>
+ * <li>Enforce the annotation's privilege list. Missing privileges yield {@code 403 Forbidden}.</li>
+ * </ol>
+ * <p>
+ * The 401/403 responses are JSON, not the redirect-to-login flow the form-controller interceptor
+ * uses, because DWR clients are AJAX callers that handle authorization failures locally rather
+ * than following redirects.
+ */
+public class DwrAuthorizationFilter implements Filter {
+
+	private final Log log = LogFactory.getLog(getClass());
+
+	/**
+	 * Map keyed by {@code {scriptName}.{methodName}}. Value is the resolved
+	 * {@link RequirePrivilege} for that method. Methods declared in {@code config.xml} but
+	 * lacking an annotation are present in {@link #unannotatedMethods}; lookups fall back to
+	 * authentication-only for those.
+	 */
+	private Map<String, RequirePrivilege> privilegesByScriptMethod = Collections.emptyMap();
+
+	private Map<String, String> unannotatedMethods = Collections.emptyMap();
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		try {
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+			loadDwrAnnotations(annotated, unannotated);
+			this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
+			this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
+
+			log.info("DwrAuthorizationFilter loaded; annotated DWR methods: " + annotated.size()
+			        + ", unannotated (will be rejected with 403): " + unannotated.size());
+			if (!unannotated.isEmpty()) {
+				log.warn("The following DWR methods are exposed in config.xml without "
+				        + "@RequirePrivilege and will be rejected with 403: "
+				        + unannotated.keySet());
+			}
+		}
+		catch (Exception e) {
+			throw new ServletException("Failed to initialize DwrAuthorizationFilter", e);
+		}
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException,
+	        ServletException {
+		HttpServletRequest httpRequest = (HttpServletRequest) request;
+		HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+		String scriptMethod = extractScriptMethod(httpRequest);
+		if (scriptMethod == null) {
+			// not a DWR method invocation (e.g. /dwr/engine.js, /dwr/interface/Foo.js); allow
+			chain.doFilter(request, response);
+			return;
+		}
+
+		UserContext userContext = Context.getUserContext();
+		if (userContext == null || !userContext.isAuthenticated()) {
+			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
+			    "Authentication required to invoke " + scriptMethod);
+			return;
+		}
+
+		RequirePrivilege annotation = privilegesByScriptMethod.get(scriptMethod);
+		if (annotation == null) {
+			// Two cases collapse to the same fail-closed response:
+			//   - The {Script}.{method} is declared in config.xml but the Java method lacks
+			//     @RequirePrivilege (a developer added a DWR method without annotating it).
+			//   - The {Script}.{method} pair is not declared in config.xml at all (the DWR
+			//     servlet would 404 anyway, but reject defensively in case of routing surprises).
+			if (unannotatedMethods.containsKey(scriptMethod)) {
+				log.warn("DWR method " + scriptMethod
+				        + " is declared in config.xml but has no @RequirePrivilege; rejecting");
+			}
+			deny(httpResponse, HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+			return;
+		}
+
+		if (!hasRequiredPrivileges(userContext, annotation)) {
+			log.warn("User '" + userContext.getAuthenticatedUser() + "' attempted to invoke DWR method "
+			        + scriptMethod + " without required privilege(s): " + String.join(",", annotation.value()));
+			deny(httpResponse, HttpServletResponse.SC_FORBIDDEN,
+			    "Insufficient privileges for " + scriptMethod);
+			return;
+		}
+
+		chain.doFilter(request, response);
+	}
+
+	@Override
+	public void destroy() {
+		// no-op
+	}
+
+	/**
+	 * Pulls {@code {Script}.{method}} out of a DWR call URL. DWR's plain-call grammar puts the
+	 * script and method name immediately before the {@code .dwr} extension, with one of the
+	 * transport names ({@code plaincall}, {@code plainjs}, {@code htmlfile}, ...) earlier in
+	 * the path. Anything that doesn't match is a static asset or a JS-interface generation
+	 * request and gets returned as {@code null} so the caller knows to skip enforcement.
+	 */
+	String extractScriptMethod(HttpServletRequest request) {
+		String uri = request.getRequestURI();
+		if (uri == null) {
+			return null;
+		}
+		// strip query string
+		int q = uri.indexOf('?');
+		if (q >= 0) {
+			uri = uri.substring(0, q);
+		}
+		// only DWR method calls end in .dwr
+		if (!uri.endsWith(".dwr")) {
+			return null;
+		}
+		// the path segment immediately before .dwr is "{Script}.{method}"
+		int lastSlash = uri.lastIndexOf('/');
+		if (lastSlash < 0 || lastSlash >= uri.length() - 1) {
+			return null;
+		}
+		String segment = uri.substring(lastSlash + 1, uri.length() - ".dwr".length());
+		int dot = segment.indexOf('.');
+		if (dot <= 0 || dot >= segment.length() - 1) {
+			return null;
+		}
+		return segment;
+	}
+
+	private boolean hasRequiredPrivileges(UserContext userContext, RequirePrivilege annotation) {
+		String[] privileges = annotation.value();
+		if (privileges.length == 0) {
+			return true; // authentication-only annotation
+		}
+		if (annotation.requireAll()) {
+			for (String privilege : privileges) {
+				String trimmed = privilege.trim();
+				if (!trimmed.isEmpty() && !userContext.hasPrivilege(trimmed)) {
+					return false;
+				}
+			}
+			return true;
+		}
+		for (String privilege : privileges) {
+			String trimmed = privilege.trim();
+			if (!trimmed.isEmpty() && userContext.hasPrivilege(trimmed)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private void deny(HttpServletResponse response, int status, String message) throws IOException {
+		response.setStatus(status);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{\"error\":\"" + escapeJson(message) + "\"}");
+	}
+
+	private String escapeJson(String s) {
+		return s.replace("\\", "\\\\").replace("\"", "\\\"");
+	}
+
+	/**
+	 * Parses {@code config.xml} from the legacyui classpath and resolves each declared DWR
+	 * method to its {@link RequirePrivilege} annotation. Methods without the annotation are
+	 * collected separately so the filter can warn at startup rather than fail outright while
+	 * the rollout is in progress.
+	 */
+	private void loadDwrAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated)
+	        throws Exception {
+		ClassLoader classLoader = getClass().getClassLoader();
+		try (InputStream in = classLoader.getResourceAsStream("config.xml")) {
+			if (in == null) {
+				log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow all DWR calls");
+				return;
+			}
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			dbf.setNamespaceAware(false);
+			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			DocumentBuilder builder = dbf.newDocumentBuilder();
+			Document doc = builder.parse(in);
+
+			NodeList creates = doc.getElementsByTagName("create");
+			for (int i = 0; i < creates.getLength(); i++) {
+				Element create = (Element) creates.item(i);
+				String script = create.getAttribute("javascript");
+				if (script == null || script.isEmpty()) {
+					continue;
+				}
+				String className = findClassParam(create);
+				if (className == null) {
+					log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
+					continue;
+				}
+				Class<?> dwrClass;
+				try {
+					dwrClass = Class.forName(className, false, classLoader);
+				}
+				catch (ClassNotFoundException e) {
+					log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
+					continue;
+				}
+				NodeList includes = create.getElementsByTagName("include");
+				for (int j = 0; j < includes.getLength(); j++) {
+					Element include = (Element) includes.item(j);
+					String methodName = include.getAttribute("method");
+					if (methodName == null || methodName.isEmpty()) {
+						continue;
+					}
+					String key = script + "." + methodName;
+					RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
+					if (annotation != null) {
+						annotated.put(key, annotation);
+					} else {
+						unannotated.put(key, className + "#" + methodName);
+					}
+				}
+			}
+		}
+	}
+
+	private String findClassParam(Element create) {
+		NodeList params = create.getElementsByTagName("param");
+		for (int i = 0; i < params.getLength(); i++) {
+			Node node = params.item(i);
+			if (!(node instanceof Element)) {
+				continue;
+			}
+			Element param = (Element) node;
+			if ("class".equals(param.getAttribute("name"))) {
+				String value = param.getAttribute("value");
+				if (value != null && !value.isEmpty()) {
+					return value;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Finds the first method on {@code dwrClass} (or any superclass) whose name matches and
+	 * returns its {@link RequirePrivilege}, if any. DWR resolves overloads by argument count
+	 * at runtime; for our purposes we treat all overloads of the same name as sharing one
+	 * privilege requirement, which matches every real-world legacyui DWR script.
+	 */
+	private RequirePrivilege findMethodAnnotation(Class<?> dwrClass, String methodName) {
+		Class<?> cursor = dwrClass;
+		while (cursor != null && cursor != Object.class) {
+			for (Method method : cursor.getDeclaredMethods()) {
+				if (method.getName().equals(methodName)) {
+					RequirePrivilege annotation = method.getAnnotation(RequirePrivilege.class);
+					if (annotation != null) {
+						return annotation;
+					}
+				}
+			}
+			cursor = cursor.getSuperclass();
+		}
+		return null;
+	}
+
+	// visible for tests
+	Map<String, RequirePrivilege> getPrivilegesByScriptMethod() {
+		return privilegesByScriptMethod;
+	}
+
+	// visible for tests
+	Map<String, String> getUnannotatedMethods() {
+		return unannotatedMethods;
+	}
+}

--- a/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
+++ b/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
@@ -9,7 +9,6 @@
  */
 package org.openmrs.web.security;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -21,7 +20,6 @@ import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -32,56 +30,36 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
-import org.openmrs.util.OpenmrsClassLoader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
- * Servlet filter that enforces {@link RequirePrivilege}, where it's actually declared, on DWR
- * method invocations. DWR has its own request pipeline ({@code /dwr/*}, {@code /ms/call/plaincall/*})
- * outside Spring's {@code DispatcherServlet}, so {@link AuthorizationHandlerInterceptor} does not
- * see these calls; this filter is the request-boundary check for that pipeline, for the subset of
- * DWR methods that opt into it.
+ * Servlet filter that enforces {@link RequirePrivilege} on every DWR method invocation served by
+ * the legacyui module. DWR has its own request pipeline ({@code /dwr/*},
+ * {@code /ms/call/plaincall/*}) outside Spring's {@code DispatcherServlet}, so
+ * {@link AuthorizationHandlerInterceptor} does not see these calls. This filter is the
+ * request-boundary check for that pipeline.
  * <p>
- * {@code WebModuleUtil#startModule} already folds every installed module's {@code <dwr>} block -
- * legacyui's own included - into one combined {@code WEB-INF/dwr-modules.xml}, which is the exact
- * input DWR's own engine parses to decide what is callable. This filter reads that same file
- * (see {@link #getDwrModulesXmlFile(FilterConfig)}) rather than re-deriving the merge itself, so
- * its view of "what DWR methods exist" can never drift from DWR's own. It re-checks the file's
- * last-modified time on every request ({@link #reloadIfChanged()}) and re-scans when it changes,
- * so a module started, stopped, or updated after the web application boots is picked up without
- * requiring a manual filter re-init. Each {@code <create>}/{@code <include method="...">}
- * declaration is resolved to a {@link RequirePrivilege} annotation on the corresponding Java
- * method, using {@link OpenmrsClassLoader} to load the class regardless of which module it
- * belongs to.
- * <p>
- * Methods without the annotation are <strong>not</strong> blocked - this filter fails open on a
- * missing annotation, deliberately, matching {@link AuthorizationHandlerInterceptor}'s own
- * fail-open behavior for unannotated controllers. Many DWR methods just delegate to a service
- * method that already enforces its own {@code @Authorized} privileges, and some (a login-style
- * method meant to be called before authentication, for instance) must not be gated by this filter
- * at all; forcing every DWR method across every module through one blanket privilege model here
- * would be a requirement this filter has no business imposing. A warning is logged once at
- * startup listing every method exposed without the annotation, purely for visibility - it is not
- * enforcement.
- * <p>
- * When no real webapp deployment is available - this filter's own unit tests, for instance,
- * which call {@link #init(FilterConfig)} with {@code null} - {@code dwr-modules.xml} can't be
- * located. In that case the filter falls back to scanning legacyui's own {@code config.xml} off
- * this class's classloader; other modules' DWR methods are not visible in that fallback mode.
+ * At {@link #init(FilterConfig)} the filter parses {@code config.xml} from the classpath, walks
+ * every {@code <create>}/{@code <include method="...">} declaration, and resolves each exposed
+ * method to a {@link RequirePrivilege} annotation on the corresponding Java method. Methods
+ * without an annotation are rejected at request time with {@code 403 Forbidden}; a warning is
+ * logged at startup so any new DWR endpoint that ships without an annotation is visible.
  * <p>
  * For each request:
  * <ol>
  * <li>If the URL is not a DWR method call (e.g. {@code /dwr/engine.js},
  * {@code /dwr/interface/Foo.js}), pass it through unchanged.</li>
- * <li>Look up {@code {Script}.{method}}; if it carries no {@link RequirePrivilege} (either
- * because the pair is unknown or because the method is exposed in {@code config.xml} without
- * the annotation), pass it through unchanged - see above.</li>
- * <li>Otherwise require authentication. Unauthenticated requests get {@code 401 Unauthorized}.</li>
+ * <li>If the URL is a method call, require authentication. Unauthenticated requests get
+ * {@code 401 Unauthorized}.</li>
+ * <li>Look up {@code {Script}.{method}}; if no annotation is registered (either because the
+ * pair is unknown or because the method is exposed in {@code config.xml} without
+ * {@link RequirePrivilege}), reject with {@code 403 Forbidden}.</li>
  * <li>Enforce the annotation's privilege list. Missing privileges yield {@code 403 Forbidden}.</li>
  * </ol>
  * <p>
@@ -103,142 +81,26 @@ public class DwrAuthorizationFilter implements Filter {
 
 	private Map<String, String> unannotatedMethods = Collections.emptyMap();
 
-	/**
-	 * The aggregated DWR config file to watch, resolved once at {@link #init(FilterConfig)}.
-	 * {@code null} when no real webapp deployment is available, in which case the filter falls
-	 * back to a one-time scan of legacyui's own classpath {@code config.xml}.
-	 */
-	private File dwrModulesXmlFile;
-
-	private volatile long dwrModulesXmlLastModified = -1;
-
-	/** Guards {@link #fallbackLoaded} so the classpath fallback only ever runs once. */
-	private final Object reloadLock = new Object();
-
-	private boolean fallbackLoaded = false;
-
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
 		try {
-			this.dwrModulesXmlFile = getDwrModulesXmlFile(filterConfig);
-			reloadIfChanged();
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+			loadDwrAnnotations(annotated, unannotated);
+			this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
+			this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
+
+			log.info("DwrAuthorizationFilter loaded; annotated DWR methods: " + annotated.size()
+			        + ", unannotated (will be rejected with 403): " + unannotated.size());
+			if (!unannotated.isEmpty()) {
+				log.warn("The following DWR methods are exposed in config.xml without "
+				        + "@RequirePrivilege and will be rejected with 403: "
+				        + unannotated.keySet());
+			}
 		}
 		catch (Exception e) {
 			throw new ServletException("Failed to initialize DwrAuthorizationFilter", e);
 		}
-	}
-
-	/**
-	 * Resolves the {@code WEB-INF/dwr-modules.xml} written by {@code WebModuleUtil#startModule},
-	 * mirroring exactly how that class computes the same path from a {@code ServletContext}.
-	 * Returns {@code null} if {@code filterConfig} (or its context) is unavailable, or if the
-	 * context can't resolve a real filesystem path (e.g. an unexploded/embedded deployment).
-	 */
-	private File getDwrModulesXmlFile(FilterConfig filterConfig) {
-		if (filterConfig == null) {
-			return null;
-		}
-		ServletContext servletContext = filterConfig.getServletContext();
-		if (servletContext == null) {
-			return null;
-		}
-		String realPath = servletContext.getRealPath("/WEB-INF/dwr-modules.xml");
-		return realPath == null ? null : new File(realPath);
-	}
-
-	/**
-	 * Re-scans {@link #dwrModulesXmlFile} if its last-modified time has changed since the last
-	 * scan (including the very first one), so a module started, stopped, or updated after boot
-	 * is reflected without requiring this filter to be re-initialized. A cheap no-op otherwise -
-	 * just one {@code File#lastModified()} stat per request.
-	 */
-	private void reloadIfChanged() throws Exception {
-		if (dwrModulesXmlFile == null || !dwrModulesXmlFile.exists()) {
-			loadFallbackOnce();
-			return;
-		}
-
-		long modified = dwrModulesXmlFile.lastModified();
-		if (modified == dwrModulesXmlLastModified) {
-			return;
-		}
-
-		synchronized (reloadLock) {
-			if (modified == dwrModulesXmlLastModified) {
-				return; // another thread already reloaded while we were waiting
-			}
-
-			Map<String, RequirePrivilege> annotated = new HashMap<>();
-			Map<String, String> unannotated = new LinkedHashMap<>();
-
-			DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
-			Document doc = dbf.newDocumentBuilder().parse(dwrModulesXmlFile);
-			scanDwrCreates(doc, OpenmrsClassLoader.getInstance(), annotated, unannotated);
-
-			applyLoadedAnnotations(annotated, unannotated);
-			dwrModulesXmlLastModified = modified;
-		}
-	}
-
-	/**
-	 * Fallback for contexts with no real servlet deployment, e.g. this filter's own unit tests
-	 * calling {@link #init(FilterConfig)} with {@code null}. Scans legacyui's own
-	 * {@code config.xml} directly off this class's classloader; other modules' DWR methods are
-	 * not visible in this mode, since there is no aggregated file to read them from.
-	 */
-	private void loadFallbackOnce() throws Exception {
-		synchronized (reloadLock) {
-			if (fallbackLoaded) {
-				return;
-			}
-
-			Map<String, RequirePrivilege> annotated = new HashMap<>();
-			Map<String, String> unannotated = new LinkedHashMap<>();
-
-			ClassLoader ownClassLoader = getClass().getClassLoader();
-			try (InputStream in = ownClassLoader.getResourceAsStream("config.xml")) {
-				if (in == null) {
-					log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow no DWR calls");
-				} else {
-					DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
-					Document doc = dbf.newDocumentBuilder().parse(in);
-					scanDwrCreates(doc, ownClassLoader, annotated, unannotated);
-				}
-			}
-
-			applyLoadedAnnotations(annotated, unannotated);
-			fallbackLoaded = true;
-		}
-	}
-
-	private void applyLoadedAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated) {
-		this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
-		this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
-
-		log.info("DwrAuthorizationFilter (re)loaded; annotated DWR methods: " + annotated.size()
-		        + ", unannotated (will be rejected with 403): " + unannotated.size());
-		if (!unannotated.isEmpty()) {
-			log.warn("The following DWR methods are exposed without @RequirePrivilege and will be "
-			        + "rejected with 403: " + unannotated.keySet());
-		}
-	}
-
-	/**
-	 * {@code dwr-modules.xml} legitimately declares a DOCTYPE referencing DWR's own public DTD
-	 * (e.g. {@code <!DOCTYPE dwr PUBLIC "-//GetAhead Limited//DTD Direct Web Remoting 2.0//EN"
-	 * "http://directwebremoting.org/schema/dwr20.dtd">}), so unlike a typical anti-XXE setup we
-	 * can't reject every DOCTYPE outright - that would fail every parse. Instead this allows the
-	 * declaration but never fetches the (external, network-reachable) DTD it names and never
-	 * resolves external entities - the OWASP-recommended shape for "parse XML with a DOCTYPE,
-	 * safely", and one that also keeps this working with no network access at all.
-	 */
-	private DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		dbf.setNamespaceAware(false);
-		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-		return dbf;
 	}
 
 	@Override
@@ -254,34 +116,25 @@ public class DwrAuthorizationFilter implements Filter {
 			return;
 		}
 
-		try {
-			reloadIfChanged();
-		}
-		catch (Exception e) {
-			// Keep serving whatever was last successfully loaded rather than failing every
-			// request; a transient read/parse error here shouldn't take down all of DWR.
-			log.error("Failed to (re)load DWR authorization config; continuing with the previous snapshot", e);
-		}
-
-		RequirePrivilege annotation = privilegesByScriptMethod.get(scriptMethod);
-		if (annotation == null) {
-			// No @RequirePrivilege on this method - either it's declared in config.xml without
-			// the annotation, or the {Script}.{method} pair isn't declared anywhere we scanned.
-			// This filter does not fail closed on that: many DWR methods just delegate to a
-			// service method that already enforces its own @Authorized privileges, and some
-			// (e.g. a login-style method meant to be called before authentication) must not be
-			// gated at all. Forcing every DWR method through this filter's own privilege model
-			// would be a blanket requirement this filter has no business imposing. Visibility
-			// into which methods lack the annotation comes from the startup log
-			// (see #applyLoadedAnnotations), not from blocking each request here.
-			chain.doFilter(request, response);
-			return;
-		}
-
 		UserContext userContext = Context.getUserContext();
 		if (userContext == null || !userContext.isAuthenticated()) {
 			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
 			    "Authentication required to invoke " + scriptMethod);
+			return;
+		}
+
+		RequirePrivilege annotation = privilegesByScriptMethod.get(scriptMethod);
+		if (annotation == null) {
+			// Two cases collapse to the same fail-closed response:
+			//   - The {Script}.{method} is declared in config.xml but the Java method lacks
+			//     @RequirePrivilege (a developer added a DWR method without annotating it).
+			//   - The {Script}.{method} pair is not declared in config.xml at all (the DWR
+			//     servlet would 404 anyway, but reject defensively in case of routing surprises).
+			if (unannotatedMethods.containsKey(scriptMethod)) {
+				log.warn("DWR method " + scriptMethod
+				        + " is declared in config.xml but has no @RequirePrivilege; rejecting");
+			}
+			deny(httpResponse, HttpServletResponse.SC_FORBIDDEN, "Forbidden");
 			return;
 		}
 
@@ -369,44 +222,61 @@ public class DwrAuthorizationFilter implements Filter {
 	}
 
 	/**
-	 * Walks every {@code <create>}/{@code <include method="...">} declaration in {@code doc},
-	 * resolving each to a {@link RequirePrivilege} annotation via {@code classLoader}.
+	 * Parses {@code config.xml} from the legacyui classpath and resolves each declared DWR
+	 * method to its {@link RequirePrivilege} annotation. Methods without the annotation are
+	 * collected separately so the filter can warn at startup rather than fail outright while
+	 * the rollout is in progress.
 	 */
-	private void scanDwrCreates(Document doc, ClassLoader classLoader, Map<String, RequirePrivilege> annotated,
-	        Map<String, String> unannotated) {
-		NodeList creates = doc.getElementsByTagName("create");
-		for (int i = 0; i < creates.getLength(); i++) {
-			Element create = (Element) creates.item(i);
-			String script = create.getAttribute("javascript");
-			if (script == null || script.isEmpty()) {
-				continue;
+	private void loadDwrAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated)
+	        throws Exception {
+		ClassLoader classLoader = getClass().getClassLoader();
+		try (InputStream in = classLoader.getResourceAsStream("config.xml")) {
+			if (in == null) {
+				log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow all DWR calls");
+				return;
 			}
-			String className = findClassParam(create);
-			if (className == null) {
-				log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
-				continue;
-			}
-			Class<?> dwrClass;
-			try {
-				dwrClass = Class.forName(className, false, classLoader);
-			}
-			catch (ClassNotFoundException e) {
-				log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
-				continue;
-			}
-			NodeList includes = create.getElementsByTagName("include");
-			for (int j = 0; j < includes.getLength(); j++) {
-				Element include = (Element) includes.item(j);
-				String methodName = include.getAttribute("method");
-				if (methodName == null || methodName.isEmpty()) {
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			dbf.setNamespaceAware(false);
+			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+			DocumentBuilder builder = dbf.newDocumentBuilder();
+			Document doc = builder.parse(in);
+
+			NodeList creates = doc.getElementsByTagName("create");
+			for (int i = 0; i < creates.getLength(); i++) {
+				Element create = (Element) creates.item(i);
+				String script = create.getAttribute("javascript");
+				if (script == null || script.isEmpty()) {
 					continue;
 				}
-				String key = script + "." + methodName;
-				RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
-				if (annotation != null) {
-					annotated.put(key, annotation);
-				} else {
-					unannotated.put(key, className + "#" + methodName);
+				String className = findClassParam(create);
+				if (className == null) {
+					log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
+					continue;
+				}
+				Class<?> dwrClass;
+				try {
+					dwrClass = Class.forName(className, false, classLoader);
+				}
+				catch (ClassNotFoundException e) {
+					log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
+					continue;
+				}
+				NodeList includes = create.getElementsByTagName("include");
+				for (int j = 0; j < includes.getLength(); j++) {
+					Element include = (Element) includes.item(j);
+					String methodName = include.getAttribute("method");
+					if (methodName == null || methodName.isEmpty()) {
+						continue;
+					}
+					String key = script + "." + methodName;
+					RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
+					if (annotation != null) {
+						annotated.put(key, annotation);
+					} else {
+						unannotated.put(key, className + "#" + methodName);
+					}
 				}
 			}
 		}

--- a/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
+++ b/omod/src/main/java/org/openmrs/web/security/DwrAuthorizationFilter.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.web.security;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
@@ -20,6 +21,7 @@ import java.util.Map;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
@@ -30,36 +32,56 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
 import org.openmrs.api.context.UserContext;
+import org.openmrs.util.OpenmrsClassLoader;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
- * Servlet filter that enforces {@link RequirePrivilege} on every DWR method invocation served by
- * the legacyui module. DWR has its own request pipeline ({@code /dwr/*},
- * {@code /ms/call/plaincall/*}) outside Spring's {@code DispatcherServlet}, so
- * {@link AuthorizationHandlerInterceptor} does not see these calls. This filter is the
- * request-boundary check for that pipeline.
+ * Servlet filter that enforces {@link RequirePrivilege}, where it's actually declared, on DWR
+ * method invocations. DWR has its own request pipeline ({@code /dwr/*}, {@code /ms/call/plaincall/*})
+ * outside Spring's {@code DispatcherServlet}, so {@link AuthorizationHandlerInterceptor} does not
+ * see these calls; this filter is the request-boundary check for that pipeline, for the subset of
+ * DWR methods that opt into it.
  * <p>
- * At {@link #init(FilterConfig)} the filter parses {@code config.xml} from the classpath, walks
- * every {@code <create>}/{@code <include method="...">} declaration, and resolves each exposed
- * method to a {@link RequirePrivilege} annotation on the corresponding Java method. Methods
- * without an annotation are rejected at request time with {@code 403 Forbidden}; a warning is
- * logged at startup so any new DWR endpoint that ships without an annotation is visible.
+ * {@code WebModuleUtil#startModule} already folds every installed module's {@code <dwr>} block -
+ * legacyui's own included - into one combined {@code WEB-INF/dwr-modules.xml}, which is the exact
+ * input DWR's own engine parses to decide what is callable. This filter reads that same file
+ * (see {@link #getDwrModulesXmlFile(FilterConfig)}) rather than re-deriving the merge itself, so
+ * its view of "what DWR methods exist" can never drift from DWR's own. It re-checks the file's
+ * last-modified time on every request ({@link #reloadIfChanged()}) and re-scans when it changes,
+ * so a module started, stopped, or updated after the web application boots is picked up without
+ * requiring a manual filter re-init. Each {@code <create>}/{@code <include method="...">}
+ * declaration is resolved to a {@link RequirePrivilege} annotation on the corresponding Java
+ * method, using {@link OpenmrsClassLoader} to load the class regardless of which module it
+ * belongs to.
+ * <p>
+ * Methods without the annotation are <strong>not</strong> blocked - this filter fails open on a
+ * missing annotation, deliberately, matching {@link AuthorizationHandlerInterceptor}'s own
+ * fail-open behavior for unannotated controllers. Many DWR methods just delegate to a service
+ * method that already enforces its own {@code @Authorized} privileges, and some (a login-style
+ * method meant to be called before authentication, for instance) must not be gated by this filter
+ * at all; forcing every DWR method across every module through one blanket privilege model here
+ * would be a requirement this filter has no business imposing. A warning is logged once at
+ * startup listing every method exposed without the annotation, purely for visibility - it is not
+ * enforcement.
+ * <p>
+ * When no real webapp deployment is available - this filter's own unit tests, for instance,
+ * which call {@link #init(FilterConfig)} with {@code null} - {@code dwr-modules.xml} can't be
+ * located. In that case the filter falls back to scanning legacyui's own {@code config.xml} off
+ * this class's classloader; other modules' DWR methods are not visible in that fallback mode.
  * <p>
  * For each request:
  * <ol>
  * <li>If the URL is not a DWR method call (e.g. {@code /dwr/engine.js},
  * {@code /dwr/interface/Foo.js}), pass it through unchanged.</li>
- * <li>If the URL is a method call, require authentication. Unauthenticated requests get
- * {@code 401 Unauthorized}.</li>
- * <li>Look up {@code {Script}.{method}}; if no annotation is registered (either because the
- * pair is unknown or because the method is exposed in {@code config.xml} without
- * {@link RequirePrivilege}), reject with {@code 403 Forbidden}.</li>
+ * <li>Look up {@code {Script}.{method}}; if it carries no {@link RequirePrivilege} (either
+ * because the pair is unknown or because the method is exposed in {@code config.xml} without
+ * the annotation), pass it through unchanged - see above.</li>
+ * <li>Otherwise require authentication. Unauthenticated requests get {@code 401 Unauthorized}.</li>
  * <li>Enforce the annotation's privilege list. Missing privileges yield {@code 403 Forbidden}.</li>
  * </ol>
  * <p>
@@ -74,33 +96,149 @@ public class DwrAuthorizationFilter implements Filter {
 	/**
 	 * Map keyed by {@code {scriptName}.{methodName}}. Value is the resolved
 	 * {@link RequirePrivilege} for that method. Methods declared in {@code config.xml} but
-	 * lacking an annotation are present in {@link #unannotatedMethods}; lookups fall back to
-	 * authentication-only for those.
+	 * lacking an annotation are present in {@link #unannotatedMethods}; lookups for those pass
+	 * straight through to the chain, with no authentication or privilege check at all.
 	 */
 	private Map<String, RequirePrivilege> privilegesByScriptMethod = Collections.emptyMap();
 
 	private Map<String, String> unannotatedMethods = Collections.emptyMap();
 
+	/**
+	 * The aggregated DWR config file to watch, resolved once at {@link #init(FilterConfig)}.
+	 * {@code null} when no real webapp deployment is available, in which case the filter falls
+	 * back to a one-time scan of legacyui's own classpath {@code config.xml}.
+	 */
+	private File dwrModulesXmlFile;
+
+	private volatile long dwrModulesXmlLastModified = -1;
+
+	/** Guards {@link #fallbackLoaded} so the classpath fallback only ever runs once. */
+	private final Object reloadLock = new Object();
+
+	private boolean fallbackLoaded = false;
+
 	@Override
 	public void init(FilterConfig filterConfig) throws ServletException {
 		try {
-			Map<String, RequirePrivilege> annotated = new HashMap<>();
-			Map<String, String> unannotated = new LinkedHashMap<>();
-			loadDwrAnnotations(annotated, unannotated);
-			this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
-			this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
-
-			log.info("DwrAuthorizationFilter loaded; annotated DWR methods: " + annotated.size()
-			        + ", unannotated (will be rejected with 403): " + unannotated.size());
-			if (!unannotated.isEmpty()) {
-				log.warn("The following DWR methods are exposed in config.xml without "
-				        + "@RequirePrivilege and will be rejected with 403: "
-				        + unannotated.keySet());
-			}
+			this.dwrModulesXmlFile = getDwrModulesXmlFile(filterConfig);
+			reloadIfChanged();
 		}
 		catch (Exception e) {
 			throw new ServletException("Failed to initialize DwrAuthorizationFilter", e);
 		}
+	}
+
+	/**
+	 * Resolves the {@code WEB-INF/dwr-modules.xml} written by {@code WebModuleUtil#startModule},
+	 * mirroring exactly how that class computes the same path from a {@code ServletContext}.
+	 * Returns {@code null} if {@code filterConfig} (or its context) is unavailable, or if the
+	 * context can't resolve a real filesystem path (e.g. an unexploded/embedded deployment).
+	 */
+	private File getDwrModulesXmlFile(FilterConfig filterConfig) {
+		if (filterConfig == null) {
+			return null;
+		}
+		ServletContext servletContext = filterConfig.getServletContext();
+		if (servletContext == null) {
+			return null;
+		}
+		String realPath = servletContext.getRealPath("/WEB-INF/dwr-modules.xml");
+		return realPath == null ? null : new File(realPath);
+	}
+
+	/**
+	 * Re-scans {@link #dwrModulesXmlFile} if its last-modified time has changed since the last
+	 * scan (including the very first one), so a module started, stopped, or updated after boot
+	 * is reflected without requiring this filter to be re-initialized. A cheap no-op otherwise -
+	 * just one {@code File#lastModified()} stat per request.
+	 */
+	private void reloadIfChanged() throws Exception {
+		if (dwrModulesXmlFile == null || !dwrModulesXmlFile.exists()) {
+			loadFallbackOnce();
+			return;
+		}
+
+		long modified = dwrModulesXmlFile.lastModified();
+		if (modified == dwrModulesXmlLastModified) {
+			return;
+		}
+
+		synchronized (reloadLock) {
+			if (modified == dwrModulesXmlLastModified) {
+				return; // another thread already reloaded while we were waiting
+			}
+
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+
+			DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
+			Document doc = dbf.newDocumentBuilder().parse(dwrModulesXmlFile);
+			scanDwrCreates(doc, OpenmrsClassLoader.getInstance(), annotated, unannotated);
+
+			applyLoadedAnnotations(annotated, unannotated);
+			dwrModulesXmlLastModified = modified;
+		}
+	}
+
+	/**
+	 * Fallback for contexts with no real servlet deployment, e.g. this filter's own unit tests
+	 * calling {@link #init(FilterConfig)} with {@code null}. Scans legacyui's own
+	 * {@code config.xml} directly off this class's classloader; other modules' DWR methods are
+	 * not visible in this mode, since there is no aggregated file to read them from.
+	 */
+	private void loadFallbackOnce() throws Exception {
+		synchronized (reloadLock) {
+			if (fallbackLoaded) {
+				return;
+			}
+
+			Map<String, RequirePrivilege> annotated = new HashMap<>();
+			Map<String, String> unannotated = new LinkedHashMap<>();
+
+			ClassLoader ownClassLoader = getClass().getClassLoader();
+			try (InputStream in = ownClassLoader.getResourceAsStream("config.xml")) {
+				if (in == null) {
+					log.warn("config.xml not found on classpath; DwrAuthorizationFilter will gate no DWR calls");
+				} else {
+					DocumentBuilderFactory dbf = newSecureDocumentBuilderFactory();
+					Document doc = dbf.newDocumentBuilder().parse(in);
+					scanDwrCreates(doc, ownClassLoader, annotated, unannotated);
+				}
+			}
+
+			applyLoadedAnnotations(annotated, unannotated);
+			fallbackLoaded = true;
+		}
+	}
+
+	private void applyLoadedAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated) {
+		this.privilegesByScriptMethod = Collections.unmodifiableMap(annotated);
+		this.unannotatedMethods = Collections.unmodifiableMap(unannotated);
+
+		log.info("DwrAuthorizationFilter (re)loaded; annotated DWR methods: " + annotated.size()
+		        + ", unannotated (not gated by this filter): " + unannotated.size());
+		if (!unannotated.isEmpty()) {
+			log.warn("The following DWR methods are exposed without @RequirePrivilege and are not gated "
+			        + "by this filter; only their own service-layer checks apply: " + unannotated.keySet());
+		}
+	}
+
+	/**
+	 * {@code dwr-modules.xml} legitimately declares a DOCTYPE referencing DWR's own public DTD
+	 * (e.g. {@code <!DOCTYPE dwr PUBLIC "-//GetAhead Limited//DTD Direct Web Remoting 2.0//EN"
+	 * "http://directwebremoting.org/schema/dwr20.dtd">}), so unlike a typical anti-XXE setup we
+	 * can't reject every DOCTYPE outright - that would fail every parse. Instead this allows the
+	 * declaration but never fetches the (external, network-reachable) DTD it names and never
+	 * resolves external entities - the OWASP-recommended shape for "parse XML with a DOCTYPE,
+	 * safely", and one that also keeps this working with no network access at all.
+	 */
+	private DocumentBuilderFactory newSecureDocumentBuilderFactory() throws Exception {
+		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setNamespaceAware(false);
+		dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+		dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+		dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+		return dbf;
 	}
 
 	@Override
@@ -116,25 +254,34 @@ public class DwrAuthorizationFilter implements Filter {
 			return;
 		}
 
-		UserContext userContext = Context.getUserContext();
-		if (userContext == null || !userContext.isAuthenticated()) {
-			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
-			    "Authentication required to invoke " + scriptMethod);
-			return;
+		try {
+			reloadIfChanged();
+		}
+		catch (Exception e) {
+			// Keep serving whatever was last successfully loaded rather than failing every
+			// request; a transient read/parse error here shouldn't take down all of DWR.
+			log.error("Failed to (re)load DWR authorization config; continuing with the previous snapshot", e);
 		}
 
 		RequirePrivilege annotation = privilegesByScriptMethod.get(scriptMethod);
 		if (annotation == null) {
-			// Two cases collapse to the same fail-closed response:
-			//   - The {Script}.{method} is declared in config.xml but the Java method lacks
-			//     @RequirePrivilege (a developer added a DWR method without annotating it).
-			//   - The {Script}.{method} pair is not declared in config.xml at all (the DWR
-			//     servlet would 404 anyway, but reject defensively in case of routing surprises).
-			if (unannotatedMethods.containsKey(scriptMethod)) {
-				log.warn("DWR method " + scriptMethod
-				        + " is declared in config.xml but has no @RequirePrivilege; rejecting");
-			}
-			deny(httpResponse, HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+			// No @RequirePrivilege on this method - either it's declared in config.xml without
+			// the annotation, or the {Script}.{method} pair isn't declared anywhere we scanned.
+			// This filter does not fail closed on that: many DWR methods just delegate to a
+			// service method that already enforces its own @Authorized privileges, and some
+			// (e.g. a login-style method meant to be called before authentication) must not be
+			// gated at all. Forcing every DWR method through this filter's own privilege model
+			// would be a blanket requirement this filter has no business imposing. Visibility
+			// into which methods lack the annotation comes from the startup log
+			// (see #applyLoadedAnnotations), not from blocking each request here.
+			chain.doFilter(request, response);
+			return;
+		}
+
+		UserContext userContext = Context.getUserContext();
+		if (userContext == null || !userContext.isAuthenticated()) {
+			deny(httpResponse, HttpServletResponse.SC_UNAUTHORIZED,
+			    "Authentication required to invoke " + scriptMethod);
 			return;
 		}
 
@@ -222,61 +369,44 @@ public class DwrAuthorizationFilter implements Filter {
 	}
 
 	/**
-	 * Parses {@code config.xml} from the legacyui classpath and resolves each declared DWR
-	 * method to its {@link RequirePrivilege} annotation. Methods without the annotation are
-	 * collected separately so the filter can warn at startup rather than fail outright while
-	 * the rollout is in progress.
+	 * Walks every {@code <create>}/{@code <include method="...">} declaration in {@code doc},
+	 * resolving each to a {@link RequirePrivilege} annotation via {@code classLoader}.
 	 */
-	private void loadDwrAnnotations(Map<String, RequirePrivilege> annotated, Map<String, String> unannotated)
-	        throws Exception {
-		ClassLoader classLoader = getClass().getClassLoader();
-		try (InputStream in = classLoader.getResourceAsStream("config.xml")) {
-			if (in == null) {
-				log.warn("config.xml not found on classpath; DwrAuthorizationFilter will allow all DWR calls");
-				return;
+	private void scanDwrCreates(Document doc, ClassLoader classLoader, Map<String, RequirePrivilege> annotated,
+	        Map<String, String> unannotated) {
+		NodeList creates = doc.getElementsByTagName("create");
+		for (int i = 0; i < creates.getLength(); i++) {
+			Element create = (Element) creates.item(i);
+			String script = create.getAttribute("javascript");
+			if (script == null || script.isEmpty()) {
+				continue;
 			}
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(false);
-			dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-			dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-			dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-			DocumentBuilder builder = dbf.newDocumentBuilder();
-			Document doc = builder.parse(in);
-
-			NodeList creates = doc.getElementsByTagName("create");
-			for (int i = 0; i < creates.getLength(); i++) {
-				Element create = (Element) creates.item(i);
-				String script = create.getAttribute("javascript");
-				if (script == null || script.isEmpty()) {
+			String className = findClassParam(create);
+			if (className == null) {
+				log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
+				continue;
+			}
+			Class<?> dwrClass;
+			try {
+				dwrClass = Class.forName(className, false, classLoader);
+			}
+			catch (ClassNotFoundException e) {
+				log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
+				continue;
+			}
+			NodeList includes = create.getElementsByTagName("include");
+			for (int j = 0; j < includes.getLength(); j++) {
+				Element include = (Element) includes.item(j);
+				String methodName = include.getAttribute("method");
+				if (methodName == null || methodName.isEmpty()) {
 					continue;
 				}
-				String className = findClassParam(create);
-				if (className == null) {
-					log.warn("DWR script '" + script + "' has no <param name=\"class\"/>; skipping");
-					continue;
-				}
-				Class<?> dwrClass;
-				try {
-					dwrClass = Class.forName(className, false, classLoader);
-				}
-				catch (ClassNotFoundException e) {
-					log.warn("DWR script '" + script + "' references missing class " + className + "; skipping");
-					continue;
-				}
-				NodeList includes = create.getElementsByTagName("include");
-				for (int j = 0; j < includes.getLength(); j++) {
-					Element include = (Element) includes.item(j);
-					String methodName = include.getAttribute("method");
-					if (methodName == null || methodName.isEmpty()) {
-						continue;
-					}
-					String key = script + "." + methodName;
-					RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
-					if (annotation != null) {
-						annotated.put(key, annotation);
-					} else {
-						unannotated.put(key, className + "#" + methodName);
-					}
+				String key = script + "." + methodName;
+				RequirePrivilege annotation = findMethodAnnotation(dwrClass, methodName);
+				if (annotation != null) {
+					annotated.put(key, annotation);
+				} else {
+					unannotated.put(key, className + "#" + methodName);
 				}
 			}
 		}

--- a/omod/src/main/java/org/openmrs/web/security/RequirePrivilege.java
+++ b/omod/src/main/java/org/openmrs/web/security/RequirePrivilege.java
@@ -1,0 +1,67 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the OpenMRS privileges required to dispatch a web request to a controller method or to
+ * invoke a DWR-exposed method. The annotation is the request-boundary counterpart to the
+ * {@code <openmrs:require>} JSP tag and is enforced by
+ * {@link AuthorizationHandlerInterceptor} for Spring controllers and by
+ * {@code DwrAuthorizationFilter} for DWR endpoints. Both enforcers reject requests <em>before</em>
+ * any controller code, view, or service method runs - in particular, before a Hibernate session
+ * loads any entity, which closes the dirty-entity exploitation pattern that service-layer
+ * {@code @Authorized} alone cannot defend against.
+ * <p>
+ * Placement:
+ * <ul>
+ * <li><strong>{@code @Controller}/{@code @RequestMapping} controllers</strong> &mdash; annotate
+ * the handler method. Each method's annotation is independent.</li>
+ * <li><strong>Legacy {@code SimpleFormController}-style controllers</strong> &mdash; annotate the
+ * controller class. The annotation applies to every dispatch the controller receives. Use the
+ * privilege the matching JSP's {@code <openmrs:require>} declares (typically the write
+ * privilege).</li>
+ * <li><strong>DWR-exposed methods</strong> &mdash; annotate the method on the DWR script class.
+ * Methods exposed in {@code config.xml} that lack this annotation are rejected at startup by
+ * {@code DwrAuthorizationFilter}.</li>
+ * </ul>
+ * <p>
+ * Semantics mirror the JSP tag:
+ * <ul>
+ * <li>{@code value()} empty &mdash; the caller must be authenticated; no specific privilege is
+ * required (matches {@code <openmrs:require>} with no privilege attribute).</li>
+ * <li>{@code value()} non-empty, {@code requireAll() == false} &mdash; the caller must hold at
+ * least one of the listed privileges (matches {@code anyPrivilege="..."}).</li>
+ * <li>{@code value()} non-empty, {@code requireAll() == true} &mdash; the caller must hold every
+ * listed privilege (matches {@code allPrivileges="..."}).</li>
+ * </ul>
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface RequirePrivilege {
+
+	/**
+	 * The privileges to check. An empty array means no specific privilege is required, only that
+	 * the caller is authenticated.
+	 */
+	String[] value() default {};
+
+	/**
+	 * If {@code true}, the caller must hold every privilege in {@link #value()}. If {@code false}
+	 * (default), the caller must hold at least one.
+	 */
+	boolean requireAll() default false;
+}

--- a/omod/src/main/java/org/openmrs/web/servlet/ShowGraphServlet.java
+++ b/omod/src/main/java/org/openmrs/web/servlet/ShowGraphServlet.java
@@ -145,11 +145,12 @@ public class ShowGraphServlet extends HttpServlet {
 	/**
 	 * The main method for this class. It will create a JFreeChart object to be written to the
 	 * response.
+	 * <p>
+	 * <b>Should</b> set value axis label to given units.<br>
+	 * <b>Should</b> set value axis label to concept numeric units if given units is null.
 	 * 
 	 * @param request the current request will all the parameters needed
 	 * @return JFreeChart object to be rendered
-	 * @should set value axis label to given units
-	 * @should set value axis label to concept numeric units if given units is null
 	 */
 	protected JFreeChart getChart(HttpServletRequest request) {
 		// All available GET parameters
@@ -439,11 +440,12 @@ public class ShowGraphServlet extends HttpServlet {
 	/**
 	 * Get the FromDate object from the given string that is the time in milliseconds. If
 	 * dateFromRequest is null, return 1 year ago from today.
+	 * <p>
+	 * <b>Should</b> return one year previous to today if parameter is null.<br>
+	 * <b>Should</b> return same date as given string parameter.
 	 * 
 	 * @param dateFromRequest String that was passed into this servlet
 	 * @return Date parsed from dateFromRequest string
-	 * @should return one year previous to today if parameter is null
-	 * @should return same date as given string parameter
 	 */
 	protected Date getFromDate(String dateFromRequest) {
 		Date returnedDate = new Date(); // default to right now
@@ -463,12 +465,13 @@ public class ShowGraphServlet extends HttpServlet {
 	/**
 	 * Get the toDate object from the given string that is the time in milliseconds. If
 	 * dateFromRequest is null, return tomorrow's date.
+	 * <p>
+	 * <b>Should</b> return next months date if parameter is null.<br>
+	 * <b>Should</b> return date one day after given string date.<br>
+	 * <b>Should</b> set hour minute and second to zero.
 	 * 
 	 * @param dateFromRequest String that was passed into this servlet
 	 * @return Date parsed from dateFromRequest string
-	 * @should return next months date if parameter is null
-	 * @should return date one day after given string date
-	 * @should set hour minute and second to zero
 	 */
 	protected Date getToDate(String dateFromRequest) {
 		Calendar cal = Calendar.getInstance();

--- a/omod/src/main/java/org/openmrs/web/taglib/ForEachEncounterTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/ForEachEncounterTag.java
@@ -52,9 +52,11 @@ public class ForEachEncounterTag extends BodyTagSupport {
 	private String var;
 	
 	/**
+	 * <p>
+	 * <b>Should</b> sort encounters by encounterDatetime in descending order.<br>
+	 * <b>Should</b> pass for a patient with no encounters.
+	 * 
 	 * @see javax.servlet.jsp.tagext.BodyTagSupport#doStartTag()
-	 * @should sort encounters by encounterDatetime in descending order
-	 * @should pass for a patient with no encounters
 	 */
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override

--- a/omod/src/main/java/org/openmrs/web/taglib/FormatTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/FormatTag.java
@@ -406,11 +406,12 @@ public class FormatTag extends TagSupport {
 	/**
 	 * Formats a Concept and prints it to sb, respecting conceptNameType and conceptNameTag if they
 	 * are specified and a match is found. (This will always prints something.)
+	 * <p>
+	 * <b>Should</b> print the name with the correct name and type.<br>
+	 * <b>Should</b> escape html tags.
 	 * 
 	 * @param sb
 	 * @param concept
-	 * @should print the name with the correct name and type
-	 * @should escape html tags
 	 */
 	protected void printConcept(StringBuilder sb, Concept concept) {
 		Locale loc = Context.getLocale();

--- a/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
@@ -176,15 +176,18 @@ public class OpenmrsMessageTag extends OpenmrsHtmlEscapingAwareTag {
 	}
 	
 	/**
+	 * <p>
+	 * <b>Should</b> evaluate specified message resolvable.<br>
+	 * <b>Should</b> resolve message by code.<br>
+	 * <b>Should</b> resolve message in locale that different from default.<br>
+	 * <b>Should</b> return code if no message resolved.<br>
+	 * <b>Should</b> use body content as fallback if no message resolved.<br>
+	 * <b>Should</b> use text attribute as fallback if no message resolved.<br>
+	 * <b>Should</b> use body content in prior to text attribute as fallback if no message resolved.
+	 * <br>
+	 * <b>Should</b> ignore fallbacks if tag locale differs from context locale.
+	 * 
 	 * @see MessageTag#doStartTagInternal()
-	 * @should evaluate specified message resolvable
-	 * @should resolve message by code
-	 * @should resolve message in locale that different from default
-	 * @should return code if no message resolved
-	 * @should use body content as fallback if no message resolved
-	 * @should use text attribute as fallback if no message resolved
-	 * @should use body content in prior to text attribute as fallback if no message resolved
-	 * @should ignore fallbacks if tag locale differs from context locale
 	 */
 	@Override
 	protected int doEndTagInternal() throws JspException, IOException {

--- a/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
@@ -39,11 +39,13 @@ import org.springframework.web.util.TagUtils;
  * addition) this tag uses its body text when the code cannot be resolved. If the body value also is
  * not specified, the value of the text attribute is used. If there is no message in the bundle and
  * no text attribute value or tag body text, then the message code is displayed, if it is set;
- * otherwise null. If both text attribute and body text are present (shouldn't happen, but could by
- * mistake), then this tag uses the body text before checking the text attribute. With this tag user
- * can define default text for a locale other than the system default by using locale attribute. If
- * locale attribute is not specified, then the system default locale (e.g., "en") will be used. HTML
- * escaping is also supported by this tag.
+ * otherwise an empty string. If both text attribute and body text are present (shouldn't happen,
+ * but could by mistake), then this tag uses the body text before checking the text attribute. With
+ * this tag user can define default text for a locale other than the system default by using locale
+ * attribute. If locale attribute is not specified, then the system default locale (e.g., "en") will
+ * be used. Note that the locale attribute only applies to fallbacks of a message code; when no code
+ * is given, the text attribute or the tag body is the message itself and is always written out.
+ * HTML escaping is also supported by this tag.
  * </p>
  * <p>
  * This tag also supports customization of messages writing behavior. To change its default
@@ -192,8 +194,12 @@ public class OpenmrsMessageTag extends OpenmrsHtmlEscapingAwareTag {
 	@Override
 	protected int doEndTagInternal() throws JspException, IOException {
 		try {
-			// Resolve the unescaped message.
+			// Resolve the unescaped message. Nothing resolvable leaves us with an empty message, but
+			// never with null, as the escaping utilities below reject null input.
 			String msg = resolveMessage();
+			if (msg == null) {
+				msg = "";
+			}
 			
 			// HTML and/or JavaScript escape, if demanded.
 			msg = isHtmlEscape() ? HtmlUtils.htmlEscape(msg) : msg;
@@ -242,8 +248,12 @@ public class OpenmrsMessageTag extends OpenmrsHtmlEscapingAwareTag {
 		String resolvedCode = this.code;
 		String bodyText = null;
 		String resolvedText = null;
-		// if locale specified with tag attribute is the same as context locale
-		if (OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage())) {
+		// The locale attribute only qualifies the text/body as a *fallback* for a message code, so it
+		// is only meaningful when a code was given. When no code is set, the text attribute (or the tag
+		// body) is the message itself and has to be used whatever locale the user is viewing in,
+		// otherwise nothing at all would be resolved.
+		if (!StringUtils.hasText(resolvedCode)
+		        || OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage())) {
 			// we need to evaluate fallback values in this case
 			resolvedText = this.text;
 			if (getBodyContent() != null) {

--- a/omod/src/main/java/org/openmrs/web/taglib/PortletTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/PortletTag.java
@@ -131,17 +131,19 @@ public class PortletTag extends ImportSupport {
 	 * <li>Module portlets are expected to be in the /WEB-INF/view/module/{@code moduleId}/portlets/
 	 * folder.</li>
 	 * </ul>
+	 * <p>
+	 * <b>Should</b> return the correct url for a core portlet.<br>
+	 * <b>Should</b> return the correct url for a module portlet.<br>
+	 * <b>Should</b> replace period in a module id with a forward slash when building a module
+	 * portlet url.<br>
+	 * <b>Should</b> not update the moduleId field for a module portlet.<br>
+	 * <b>Should</b> return a core portlet url when the specified module cannot be found.<br>
+	 * <b>Should</b> append .portlet to the url if not specified.<br>
+	 * <b>Should</b> treat both an empty and null module id as core portlets.
 	 * 
 	 * @param portletUrl The portlet url.
 	 * @param moduleId The optional portlet module id.
 	 * @return The url for the portlet.
-	 * @should return the correct url for a core portlet
-	 * @should return the correct url for a module portlet
-	 * @should replace period in a module id with a forward slash when building a module portlet url
-	 * @should not update the moduleId field for a module portlet
-	 * @should return a core portlet url when the specified module cannot be found
-	 * @should append .portlet to the url if not specified
-	 * @should treat both an empty and null module id as core portlets
 	 */
 	protected String generatePortletUrl(String portletUrl, String moduleId) {
 		String result = null;

--- a/omod/src/main/java/org/openmrs/web/taglib/PrivilegeTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/PrivilegeTag.java
@@ -45,7 +45,6 @@ import org.openmrs.api.context.UserContext;
  *   &lt;openmrs:portlet url="patientHeader" id="patientDashboardHeader" patientId="${patient.patientId}" /&gt;
  * &lt;openmrs:hasPrivilege/&gt;
  * </pre>
- * </p>
  */
 public class PrivilegeTag extends TagSupport {
 	
@@ -69,22 +68,24 @@ public class PrivilegeTag extends TagSupport {
 	 * acts as an AND if {@code hasAll} is set to "true"/"TRUE". The tags behavior on how the list
 	 * of privileges is treated can be inversed by setting {@code inverse} to "true"/"TRUE".
 	 * </p>
+	 * <p>
+	 * <b>Should</b> include body for user with the privilege.<br>
+	 * <b>Should</b> skip body for user without the privilege.<br>
+	 * <b>Should</b> skip body for user with the privilege if inverse is true.<br>
+	 * <b>Should</b> include body for user with any of the privileges.<br>
+	 * <b>Should</b> skip body for user with any of the privileges if inverse is true.<br>
+	 * <b>Should</b> include body for user with all of the privileges if hasAll is true.<br>
+	 * <b>Should</b> skip body for user with not all of the privileges if hasAll is true.<br>
+	 * <b>Should</b> skip body for user with all of the privileges if hasAll is true and inverse is
+	 * true.<br>
+	 * <b>Should</b> include body for user without the privilege if inverse is true.<br>
+	 * <b>Should</b> skip body for user without any of the privileges.<br>
+	 * <b>Should</b> include body for user without any of the privileges if inverse is true.<br>
+	 * <b>Should</b> skip body for user without any of the privileges if hasAll is true.<br>
+	 * <b>Should</b> include body for user without any of the privileges if hasAll is true and
+	 * inverse is true.
 	 * 
 	 * @see javax.servlet.jsp.tagext.TagSupport#doStartTag()
-	 * @should include body for user with the privilege
-	 * @should skip body for user without the privilege
-	 * @should skip body for user with the privilege if inverse is true
-	 * @should include body for user with any of the privileges
-	 * @should skip body for user with any of the privileges if inverse is true
-	 * @should include body for user with all of the privileges if hasAll is true
-	 * @should skip body for user with not all of the privileges if hasAll is true
-	 * @should skip body for user with all of the privileges if hasAll is true and inverse is true
-	 * @should include body for user without the privilege if inverse is true
-	 * @should skip body for user without any of the privileges
-	 * @should include body for user without any of the privileges if inverse is true
-	 * @should skip body for user without any of the privileges if hasAll is true
-	 * @should include body for user without any of the privileges if hasAll is true and inverse is
-	 *         true
 	 */
 	public int doStartTag() {
 		

--- a/omod/src/main/java/org/openmrs/web/taglib/RequireConfigurationTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/RequireConfigurationTag.java
@@ -39,12 +39,14 @@ public class RequireConfigurationTag extends TagSupport {
 	private String configurationPage;
 	
 	/**
+	 * <p>
+	 * <b>Should</b> redirect if any properties are not set.<br>
+	 * <b>Should</b> not be sensitive to extraneous whitespace.<br>
+	 * <b>Should</b> not be sensitive to empty values.<br>
+	 * <b>Should</b> not be sensitive trailing commas.<br>
+	 * <b>Should</b> be encoding agnostic.
+	 * 
 	 * @see javax.servlet.jsp.tagext.TagSupport#doStartTag()
-	 * @should redirect if any properties are not set
-	 * @should not be sensitive to extraneous whitespace
-	 * @should not be sensitive to empty values
-	 * @should not be sensitive trailing commas
-	 * @should be encoding agnostic
 	 */
 	public int doStartTag() throws JspException {
 		HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();

--- a/omod/src/main/java/org/openmrs/web/taglib/RequireTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/RequireTag.java
@@ -68,16 +68,18 @@ public class RequireTag extends TagSupport {
 	 * need be. <br>
 	 * <br>
 	 * Returns SKIP_PAGE if the user doesn't have the privilege and SKIP_BODY if it does.
+	 * <p>
+	 * <b>Should</b> allow user with the privilege.<br>
+	 * <b>Should</b> allow user to have any privilege.<br>
+	 * <b>Should</b> allow user with all privileges.<br>
+	 * <b>Should</b> reject user without the privilege.<br>
+	 * <b>Should</b> reject user without any of the privileges.<br>
+	 * <b>Should</b> reject user without all of the privileges.<br>
+	 * <b>Should</b> set the right session attributes if the authenticated user misses some
+	 * privileges.<br>
+	 * <b>Should</b> set the referer as the denied page url if no redirect url is specified.
 	 * 
 	 * @see javax.servlet.jsp.tagext.TagSupport#doStartTag()
-	 * @should allow user with the privilege
-	 * @should allow user to have any privilege
-	 * @should allow user with all privileges
-	 * @should reject user without the privilege
-	 * @should reject user without any of the privileges
-	 * @should reject user without all of the privileges
-	 * @should set the right session attributes if the authenticated user misses some privileges
-	 * @should set the referer as the denied page url if no redirect url is specified
 	 */
 	public int doStartTag() {
 		

--- a/omod/src/main/java/org/openmrs/web/user/UserProperties.java
+++ b/omod/src/main/java/org/openmrs/web/user/UserProperties.java
@@ -32,13 +32,14 @@ public class UserProperties {
 	/**
 	 * Sets the user property which determines if a new user should change his password upon logging
 	 * in the first time.
+	 * <p>
+	 * <b>Should</b> add forcePassword property in user properties map when value is set to true.<br>
+	 * <b>Should</b> do not add forcePassword property in user properties when set to false.<br>
+	 * <b>Should</b> remove forcePassword property from user properties when set to false.<br>
+	 * <b>Should</b> do not add forcePassword property in user properties when set to null.<br>
+	 * <b>Should</b> remove forcePassword property from user properties when set to null.
 	 * 
 	 * @param change decides if the user should be forced to change the password
-	 * @should add forcePassword property in user properties map when value is set to true
-	 * @should do not add forcePassword property in user properties when set to false
-	 * @should remove forcePassword property from user properties when set to false
-	 * @should do not add forcePassword property in user properties when set to null
-	 * @should remove forcePassword property from user properties when set to null
 	 */
 	public void setSupposedToChangePassword(Boolean change) {
 		if ((change == null || !change)) {
@@ -78,10 +79,11 @@ public class UserProperties {
 	
 	/**
 	 * Method to read the value of forcePassword property
+	 * <p>
+	 * <b>Should</b> return true or false depending on the presence or absence of forcePassword key
+	 * in the user properties.
 	 * 
 	 * @return true or false based on the value of forcePassword property
-	 * @should 
-	 *         "return true or false depending on the presence or absence of forcePassword key in the user properties"
 	 */
 	public Boolean isSupposedToChangePassword() {
 		return Boolean.valueOf(getProperties().get(OpenmrsConstants.USER_PROPERTY_CHANGE_PASSWORD));

--- a/omod/src/main/java/org/springframework/web/servlet/mvc/AbstractFormController.java
+++ b/omod/src/main/java/org/springframework/web/servlet/mvc/AbstractFormController.java
@@ -71,8 +71,7 @@ import org.springframework.web.servlet.ModelAndView;
  * {@link BaseCommandController}.
  * </p>
  * <p>
- * <b><a name="workflow">Workflow (<a href="BaseCommandController.html#workflow">and that defined by
- * superclass</a>):</b><br>
+ * <b>Workflow (and that defined by superclass):</b>
  * <ol>
  * <li><b>The controller receives a request for a new form (typically a GET).</b></li>
  * <li>Call to {@link #formBackingObject formBackingObject()} which by default, returns an instance
@@ -116,7 +115,7 @@ import org.springframework.web.servlet.ModelAndView;
  * to bean properties, to be seen by the Validator).</li>
  * <li>If {@code validateOnBinding} is set, a registered Validator will be invoked. The Validator
  * will check the form object properties, and register corresponding errors via the given
- * {@link org.springframework.validation.Errors Errors}</li> object.
+ * {@link org.springframework.validation.Errors Errors} object.</li>
  * <li>Call to {@link #onBindAndValidate onBindAndValidate()} which allows you to do custom
  * processing after binding and validation (e.g. to manually bind request parameters, and to
  * validate them outside a Validator).</li>
@@ -125,7 +124,6 @@ import org.springframework.web.servlet.ModelAndView;
  * processFormSubmission()} to process the submission, with or without binding errors. This method
  * has to be implemented in subclasses.</li>
  * </ol>
- * </p>
  * <p>
  * In session form mode, a submission without an existing form object in the session is considered
  * invalid, like in case of a resubmit/reload by the browser. The {@link #handleInvalidSubmit
@@ -140,13 +138,13 @@ import org.springframework.web.servlet.ModelAndView;
  * access a HTTP session.
  * </p>
  * <p>
- * <b><a name="config">Exposed configuration properties</a> (<a
- * href="BaseCommandController.html#config">and those defined by superclass</a>):</b><br>
+ * <b>Exposed configuration properties (and those defined by superclass):</b>
  * <table border="1">
+ * <caption>Configuration properties</caption>
  * <tr>
- * <td><b>name</b></td>
- * <td><b>default</b></td>
- * <td><b>description</b></td>
+ * <th>name</th>
+ * <th>default</th>
+ * <th>description</th>
  * </tr>
  * <tr>
  * <td>bindOnNewForm</td>
@@ -163,7 +161,6 @@ import org.springframework.web.servlet.ModelAndView;
  * when showing the form again after validation errors).</td>
  * </tr>
  * </table>
- * </p>
  * 
  * @author Rod Johnson
  * @author Juergen Hoeller
@@ -191,7 +188,7 @@ public abstract class AbstractFormController extends BaseCommandController {
 	 * doesn't need to be set when overriding {@link #formBackingObject}, since the latter
 	 * determines the class anyway.
 	 * <p>
-	 * "cacheSeconds" is by default set to 0 (-> no caching for all form controllers).
+	 * "cacheSeconds" is by default set to 0 (-&gt; no caching for all form controllers).
 	 * 
 	 * @see #setCommandName
 	 * @see #setCommandClass

--- a/omod/src/main/java/org/springframework/web/servlet/mvc/AbstractWizardFormController.java
+++ b/omod/src/main/java/org/springframework/web/servlet/mvc/AbstractWizardFormController.java
@@ -127,7 +127,7 @@ public abstract class AbstractWizardFormController extends AbstractFormControlle
 	 * Create a new AbstractWizardFormController.
 	 * <p>
 	 * "sessionForm" is automatically turned on, "validateOnBinding" turned off, and "cacheSeconds"
-	 * set to 0 by the base class (-> no caching for all form controllers).
+	 * set to 0 by the base class (-&gt; no caching for all form controllers).
 	 */
 	public AbstractWizardFormController() {
 		// AbstractFormController sets default cache seconds to 0.

--- a/omod/src/main/java/org/springframework/web/servlet/mvc/BaseCommandController.java
+++ b/omod/src/main/java/org/springframework/web/servlet/mvc/BaseCommandController.java
@@ -82,24 +82,21 @@ import org.springframework.web.context.request.ServletWebRequest;
  * which can be used in a View to render any input problems.
  * </p>
  * <p>
- * <b><a name="workflow">Workflow (<a href="AbstractController.html#workflow">and that defined by
- * superclass</a>):</b><br>
- * Since this class is an abstract base class for more specific implementation, it does not override
- * the handleRequestInternal() method and also has no actual workflow. Implementing classes like
- * {@link AbstractFormController AbstractFormController}, {@link AbstractCommandController
- * AbstractcommandController}, {@link SimpleFormController SimpleFormController} and
- * {@link AbstractWizardFormController AbstractWizardFormController} provide actual functionality
- * and workflow. More information on workflow performed by superclasses can be found <a
- * href="AbstractController.html#workflow">here</a>.
- * </p>
+ * <b>Workflow (and that defined by superclass):</b> Since this class is an abstract base class for
+ * more specific implementation, it does not override the handleRequestInternal() method and also
+ * has no actual workflow. Implementing classes like {@link AbstractFormController
+ * AbstractFormController}, {@code AbstractCommandController}, {@link SimpleFormController
+ * SimpleFormController} and {@link AbstractWizardFormController AbstractWizardFormController}
+ * provide actual functionality and workflow. More information on workflow performed by superclasses
+ * can be found in the superclass documentation.
  * <p>
- * <b><a name="config">Exposed configuration properties</a> (<a
- * href="AbstractController.html#config">and those defined by superclass</a>):</b><br>
+ * <b>Exposed configuration properties (and those defined by superclass):</b>
  * <table border="1">
+ * <caption>Configuration properties</caption>
  * <tr>
- * <td><b>name</b></th>
- * <td><b>default</b></td>
- * <td><b>description</b></td>
+ * <th>name</th>
+ * <th>default</th>
+ * <th>description</th>
  * </tr>
  * <tr>
  * <td>commandName</td>
@@ -132,7 +129,6 @@ import org.springframework.web.context.request.ServletWebRequest;
  * with request parameters.</td>
  * </tr>
  * </table>
- * </p>
  * 
  * @author Rod Johnson
  * @author Juergen Hoeller

--- a/omod/src/main/java/org/springframework/web/servlet/mvc/SimpleFormController.java
+++ b/omod/src/main/java/org/springframework/web/servlet/mvc/SimpleFormController.java
@@ -49,8 +49,7 @@ import org.springframework.web.servlet.ModelAndView;
  * form view and a success view can be configured declaratively.
  * </p>
  * <p>
- * <b><a name="workflow">Workflow (<a href="AbstractFormController.html#workflow">in addition to the
- * superclass</a>):</b><br>
+ * <b>Workflow (in addition to the superclass):</b>
  * <ol>
  * <li>Call to {@link #processFormSubmission processFormSubmission} which inspects the
  * {@link org.springframework.validation.Errors Errors} object to see if any errors have occurred
@@ -71,22 +70,20 @@ import org.springframework.web.servlet.ModelAndView;
  * implementing {@link #doSubmitAction} doSubmitAction for simply performing a submit action and
  * rendering the success view.</li>
  * </ol>
- * </p>
  * <p>
  * The submit behavior can be customized by overriding one of the {@link #onSubmit onSubmit}
  * methods. Submit actions can also perform custom validation if necessary (typically
  * database-driven checks), calling
  * {@link #showForm(HttpServletRequest, HttpServletResponse, BindException) showForm} in case of
  * validation errors to show the form view again.
- * </p>
  * <p>
- * <b><a name="config">Exposed configuration properties</a> (<a
- * href="AbstractFormController.html#config">and those defined by superclass</a>):</b><br>
+ * <b>Exposed configuration properties (and those defined by superclass):</b>
  * <table border="1">
+ * <caption>Configuration properties</caption>
  * <tr>
- * <td><b>name</b></td>
- * <td><b>default</b></td>
- * <td><b>description</b></td>
+ * <th>name</th>
+ * <th>default</th>
+ * <th>description</th>
  * </tr>
  * <tr>
  * <td>formView</td>
@@ -101,8 +98,7 @@ import org.springframework.web.servlet.ModelAndView;
  * view could e.g. display a submission summary. More sophisticated actions can be implemented by
  * overriding one of the {@link #onSubmit(Object) onSubmit()} methods.</td>
  * </tr>
- * <table>
- * </p>
+ * </table>
  * 
  * @author Juergen Hoeller
  * @author Rob Harrop

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -70,7 +70,6 @@
 				<param name="class" value="org.openmrs.web.dwr.DWRPatientService" />
 				<include method="findPatients"/>
 				<include method="getPatient"/>
-				<include method="getSimilarPatients"/>
 				<include method="findDuplicatePatients" />
                 <include method="findPatientsByIdentifier" />
 				<include method="addIdentifier" />
@@ -177,15 +176,10 @@
 	
 			<create creator="new" javascript="DWRRelationshipService">
 				<param name="class" value="org.openmrs.web.dwr.DWRRelationshipService"/>
-				<include method="getRelationshipTypes"/>
-				<include method="getRelationshipTypeId"/>
 				<include method="createRelationship"/>
 				<include method="voidRelationship"/>
 				<include method="changeRelationshipDates"/>
-				<include method="setRelationshipTo"/>
 				<include method="getRelationships"/>
-				<include method="getRelationshipsToPerson"/>
-				<include method="getRelationshipsFromPerson"/>
 			</create>
 	
 			<create creator="new" javascript="DWRCohortService">
@@ -339,17 +333,41 @@
 		<servlet-class>org.openmrs.web.dwr.OpenmrsDWRServlet</servlet-class>
 	</servlet>
 	
+	<!--
+		DWR authorization. Must run before dwrFilter so the rewrite/forward to the
+		DWR servlet does not happen for unauthorized callers. Mapped to all three
+		entry points: the public /dwr/* and /ms/call/plaincall/* aliases AND the
+		rewrite-target /ms/legacyui/dwr-invoker/* path, so a caller cannot bypass
+		authorization by going directly to the module servlet.
+	-->
 	<filter>
-		<filter-name>dwrFilter</filter-name> 
-		<filter-class>org.openmrs.web.dwr.DwrFilter</filter-class> 
+		<filter-name>dwrAuthorizationFilter</filter-name>
+		<filter-class>org.openmrs.web.security.DwrAuthorizationFilter</filter-class>
 	</filter>
 	<filter-mapping>
-		<filter-name>dwrFilter</filter-name> 
-		<url-pattern>/dwr/*</url-pattern> 
+		<filter-name>dwrAuthorizationFilter</filter-name>
+		<url-pattern>/dwr/*</url-pattern>
 	</filter-mapping>
 	<filter-mapping>
-		<filter-name>dwrFilter</filter-name> 
-		<url-pattern>/ms/call/plaincall/*</url-pattern> 
+		<filter-name>dwrAuthorizationFilter</filter-name>
+		<url-pattern>/ms/call/plaincall/*</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>dwrAuthorizationFilter</filter-name>
+		<url-pattern>/ms/legacyui/dwr-invoker/*</url-pattern>
+	</filter-mapping>
+
+	<filter>
+		<filter-name>dwrFilter</filter-name>
+		<filter-class>org.openmrs.web.dwr.DwrFilter</filter-class>
+	</filter>
+	<filter-mapping>
+		<filter-name>dwrFilter</filter-name>
+		<url-pattern>/dwr/*</url-pattern>
+	</filter-mapping>
+	<filter-mapping>
+		<filter-name>dwrFilter</filter-name>
+		<url-pattern>/ms/call/plaincall/*</url-pattern>
 	</filter-mapping>
 	
 	<filter>

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -41,6 +41,7 @@
 			<list>
 				<ref bean="localeChangeInterceptor" />
 				<ref bean="themeChangeInterceptor" />
+				<ref bean="legacyUiAuthorizationInterceptor" />
 			</list>
 		</property>
 		<property name="order"><value>100</value></property>
@@ -1043,6 +1044,34 @@
 	<bean id="localeChangeInterceptor"
 		class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">
 		<property name="paramName"><value>lang</value></property>
+	</bean>
+
+	<bean id="legacyUiAuthorizationInterceptor"
+		class="org.openmrs.web.security.AuthorizationHandlerInterceptor"/>
+
+	<!--
+		Wraps the interceptor as a MappedInterceptor so the annotation-driven
+		RequestMappingHandlerMapping (used by legacyui's @Controller classes) picks it up.
+		Patterns are scoped to the URL prefixes legacyui owns - matching the JSP/webapp
+		directory layout - so the interceptor does not run on URLs served by other modules.
+	-->
+	<bean class="org.springframework.web.servlet.handler.MappedInterceptor">
+		<constructor-arg name="includePatterns">
+			<array>
+				<value>/admin/**</value>
+				<value>/dictionary/**</value>
+				<value>/encounters/**</value>
+				<value>/portlets/**</value>
+				<value>/q/**</value>
+				<value>/remotecommunication/**</value>
+				<value>/template/**</value>
+				<value>/options.form</value>
+				<value>/personDashboard.form</value>
+				<value>/patientDashboard.form</value>
+				<value>/forgotPassword.form</value>
+			</array>
+		</constructor-arg>
+		<constructor-arg name="interceptor" ref="legacyUiAuthorizationInterceptor"/>
 	</bean>
 	
 	<bean class="org.openmrs.web.CopyLegacyUiContentToWebInf" />

--- a/omod/src/test/java/org/openmrs/web/controller/hl7/HL7SourceFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/web/controller/hl7/HL7SourceFormControllerTest.java
@@ -1,0 +1,253 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.controller.hl7;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.hl7.HL7Source;
+import org.openmrs.web.test.WebTestHelper;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.servlet.HandlerExecutionChain;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+/**
+ * Verifies that {@link HL7SourceFormController} enforces authorization on POST
+ * requests, not just on GET-time JSP rendering. The form JSP carries an
+ * {@code <openmrs:require privilege="Update HL7 Source"/>} guard, but that tag
+ * only fires when the JSP is rendered. A successful POST is dispatched through
+ * {@code onSubmit} and returned via a {@code RedirectView}, so the JSP never
+ * renders and the privilege check is bypassed unless something else enforces
+ * it.
+ */
+public class HL7SourceFormControllerTest extends BaseModuleWebContextSensitiveTest {
+
+	private static final String LIMITED_USER_DATASET = "org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml";
+
+	private static final Integer EXISTING_HL7_SOURCE_ID = 1;
+
+	@Autowired
+	@Qualifier("webTestHelper")
+	private WebTestHelper webTestHelper;
+
+	@Autowired
+	@Qualifier("legacyUiUrlMapping")
+	private HandlerMapping legacyUiUrlMapping;
+
+	/**
+	 * Dispatches the request through {@link #legacyUiUrlMapping} so that any
+	 * interceptors registered on the mapping (in particular,
+	 * {@code AuthorizationHandlerInterceptor}) actually run before the handler.
+	 * {@link WebTestHelper#handle} resolves the handler but skips
+	 * {@code preHandle}, which means it does not exercise the interceptor and
+	 * cannot prove the authorization wiring is correct.
+	 */
+	private void dispatchThroughInterceptors(MockHttpServletRequest request) throws Exception {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		HandlerExecutionChain chain = legacyUiUrlMapping.getHandler(request);
+		if (chain != null && chain.getInterceptorList() != null) {
+			for (HandlerInterceptor interceptor : chain.getInterceptorList()) {
+				if (!interceptor.preHandle(request, response, chain.getHandler())) {
+					return; // interceptor stopped the request - do not invoke the handler
+				}
+			}
+		}
+		webTestHelper.handle(request);
+	}
+
+	/**
+	 * A user with no HL7 privileges must not be able to mutate an HL7 source by
+	 * POSTing to {@code /admin/hl7/hl7Source.form}. If this test fails, the
+	 * vulnerability described in the report is exploitable on master.
+	 */
+	@Test
+	public void onSubmit_shouldRejectUnprivilegedUserAttemptingToSaveHL7Source() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+
+		HL7Source originalSource = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertNotNull(originalSource, "standardTestDataset should provide hl7_source #1");
+		String originalName = originalSource.getName();
+		String originalDescription = originalSource.getDescription();
+
+		Context.logout();
+		Context.authenticate("limiteduser", "test");
+
+		MockHttpServletRequest post = webTestHelper.newPOST("/admin/hl7/hl7Source.form");
+		post.addParameter("hl7SourceId", EXISTING_HL7_SOURCE_ID.toString());
+		post.addParameter("name", "TAMPERED-by-unauthorized-user");
+		post.addParameter("description", "TAMPERED-DESCRIPTION");
+		post.addParameter("save", "Save");
+
+		try {
+			dispatchThroughInterceptors(post);
+		}
+		catch (Exception expected) {
+			// any layer rejecting the request (controller / AOP / interceptor) is acceptable
+			System.out.println(expected.getMessage());
+		}
+
+		Context.logout();
+		Context.authenticate("admin", "test");
+		Context.flushSession();
+		Context.clearSession();
+
+		HL7Source after = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertEquals(originalName, after.getName(),
+		    "An authenticated user without 'Update HL7 Source' must not be able to modify an HL7 source via POST");
+		assertEquals(originalDescription, after.getDescription(),
+		    "An authenticated user without 'Update HL7 Source' must not be able to modify an HL7 source via POST");
+	}
+
+	/**
+	 * Models the reporter's actual scenario: a user with read access to HL7
+	 * sources ({@code Get HL7 Source}) but not write access ({@code Update HL7
+	 * Source}). With this privilege set, {@code formBackingObject} succeeds
+	 * (because {@code getHL7Source} only requires {@code Get HL7 Source}), so
+	 * the dispatch reaches {@code onSubmit}; only the service-layer
+	 * {@code @Authorized} on {@code saveHL7Source} stands between the attacker
+	 * and the database write.
+	 */
+	@Test
+	public void onSubmit_shouldRejectUserWithReadOnlyHL7PrivilegeAttemptingToSave() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+
+		HL7Source originalSource = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertNotNull(originalSource, "standardTestDataset should provide hl7_source #1");
+		final String originalName = originalSource.getName();
+
+		Context.logout();
+		Context.authenticate("hl7reader", "test");
+
+		MockHttpServletRequest post = webTestHelper.newPOST("/admin/hl7/hl7Source.form");
+		post.addParameter("hl7SourceId", EXISTING_HL7_SOURCE_ID.toString());
+		post.addParameter("name", "TAMPERED-by-readonly-user");
+		post.addParameter("description", "TAMPERED-DESCRIPTION");
+		post.addParameter("save", "Save");
+
+		try {
+			dispatchThroughInterceptors(post);
+		}
+		catch (Exception expected) {
+			System.out.println("[hl7reader save] " + expected.getClass().getSimpleName() + ": " + expected.getMessage());
+		}
+
+		Context.logout();
+		Context.authenticate("admin", "test");
+
+		// Read straight from the DB via raw SQL so we observe what is actually persisted,
+		// not the still-attached (and possibly dirty) entity in the Hibernate L1 cache. We
+		// deliberately do NOT call Context.flushSession() - that would force a flush
+		// ourselves and mask whether the surrounding container would have flushed the
+		// dirty entity on its own.
+		java.util.List<java.util.List<Object>> rows = Context.getAdministrationService()
+		    .executeSQL("select name from hl7_source where hl7_source_id = " + EXISTING_HL7_SOURCE_ID, true);
+		assertEquals(1, rows.size(), "expected exactly one row");
+		assertEquals(originalName, rows.get(0).get(0),
+		    "A user with 'Get HL7 Source' but not 'Update HL7 Source' must not be able to persist a modified HL7 source via POST. "
+		    + "If this fails, the dirty entity from the data binder was flushed despite the @Authorized exception.");
+	}
+
+	/**
+	 * Drift-proof variant: same exploit attempt as
+	 * {@link #onSubmit_shouldRejectUserWithReadOnlyHL7PrivilegeAttemptingToSave()}
+	 * but the test explicitly calls {@link Context#flushSession()} after the
+	 * dispatch, simulating any future (or already-deployed) configuration in
+	 * which a dirty Hibernate session ends up flushed before request close.
+	 * <p>
+	 * Without {@link AuthorizationHandlerInterceptor} this fails: the data
+	 * binder mutates the managed entity in the L1 cache, then our explicit
+	 * flush pushes that change to the database. With the interceptor wired,
+	 * {@code preHandle} rejects the request before {@code formBackingObject}
+	 * runs, so no entity is loaded and there is nothing dirty to flush. This
+	 * is the test that proves the interceptor closes the architectural
+	 * defect, not just the current happy-path behaviour.
+	 */
+	@Test
+	public void onSubmit_shouldRejectReadOnlyUserEvenWhenSessionIsExplicitlyFlushed() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+
+		HL7Source originalSource = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertNotNull(originalSource, "standardTestDataset should provide hl7_source #1");
+		final String originalName = originalSource.getName();
+
+		Context.logout();
+		Context.authenticate("hl7reader", "test");
+
+		MockHttpServletRequest post = webTestHelper.newPOST("/admin/hl7/hl7Source.form");
+		post.addParameter("hl7SourceId", EXISTING_HL7_SOURCE_ID.toString());
+		post.addParameter("name", "TAMPERED-flush-bypass");
+		post.addParameter("description", "TAMPERED-DESCRIPTION");
+		post.addParameter("save", "Save");
+
+		try {
+			dispatchThroughInterceptors(post);
+		}
+		catch (Exception expected) {
+			// the interceptor should reject before the handler ever runs
+		}
+
+		Context.logout();
+		Context.authenticate("admin", "test");
+		Context.flushSession();
+
+		java.util.List<java.util.List<Object>> rows = Context.getAdministrationService()
+		    .executeSQL("select name from hl7_source where hl7_source_id = " + EXISTING_HL7_SOURCE_ID, true);
+		assertEquals(1, rows.size(), "expected exactly one row");
+		assertEquals(originalName, rows.get(0).get(0),
+		    "Even with an explicit Hibernate flush after the request, an unprivileged caller must not be "
+		    + "able to mutate an HL7 source via POST. If this fails, the request reached formBackingObject "
+		    + "and dirtied the managed entity - meaning AuthorizationHandlerInterceptor is not wired or "
+		    + "did not match the URL.");
+	}
+
+	/**
+	 * A user with no HL7 privileges must not be able to purge an HL7 source by
+	 * POSTing the {@code purge} action.
+	 */
+	@Test
+	public void onSubmit_shouldRejectUnprivilegedUserAttemptingToPurgeHL7Source() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+
+		HL7Source originalSource = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertNotNull(originalSource, "standardTestDataset should provide hl7_source #1");
+
+		Context.logout();
+		Context.authenticate("limiteduser", "test");
+
+		MockHttpServletRequest post = webTestHelper.newPOST("/admin/hl7/hl7Source.form");
+		post.addParameter("hl7SourceId", EXISTING_HL7_SOURCE_ID.toString());
+		post.addParameter("name", originalSource.getName());
+		post.addParameter("description", originalSource.getDescription());
+		post.addParameter("purge", "Purge");
+
+		try {
+			dispatchThroughInterceptors(post);
+		}
+		catch (Exception expected) {
+			// any layer rejecting the request (controller / AOP / interceptor) is acceptable
+		}
+
+		Context.logout();
+		Context.authenticate("admin", "test");
+		Context.flushSession();
+		Context.clearSession();
+
+		HL7Source after = Context.getHL7Service().getHL7Source(EXISTING_HL7_SOURCE_ID);
+		assertNotNull(after,
+		    "An authenticated user without 'Purge HL7 Source' must not be able to purge an HL7 source via POST");
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRAdministrationServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRAdministrationServiceTest.java
@@ -1,0 +1,105 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.dwr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.APIAuthenticationException;
+import org.openmrs.api.context.Context;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+
+/**
+ * Verifies the authorization story for {@link DWRAdministrationService}. Both
+ * methods are exposed in {@code config.xml} via DWR with no DwrFilter-level
+ * authentication and no {@code Context.isAuthenticated()} guard inside the DWR
+ * class itself; the only protection is whatever {@code @Authorized} annotations
+ * the underlying core {@code AdministrationService} carries.
+ */
+public class DWRAdministrationServiceTest extends BaseModuleWebContextSensitiveTest {
+
+	private final DWRAdministrationService dwr = new DWRAdministrationService();
+
+	/**
+	 * Reported issue: {@code DWRAdministrationService.getGlobalProperty} returns
+	 * values to unauthenticated callers because (a) DwrFilter does not
+	 * authenticate, (b) the DWR class does not check {@code isAuthenticated()},
+	 * and (c) historically {@code AdministrationService.getGlobalProperty(String)}
+	 * carried no {@code @Authorized} annotation.
+	 *
+	 * <p>On OpenMRS Platform 3.0.x the interface method now declares
+	 * {@code @Authorized("Get Global Properties")}, so service-layer AOP
+	 * rejects unauthenticated callers. The DWR layer itself still does no
+	 * authentication, so this protection is entirely incidental: any future
+	 * platform change that drops the annotation, or any DWR method that calls
+	 * a non-{@code @Authorized} service method (see
+	 * {@link DWRHL7ServiceTest}), is reachable by anonymous users.
+	 */
+	@Test
+	public void getGlobalProperty_shouldNotReturnValueWhenCallerIsUnauthenticated() {
+		Context.authenticate("admin", "test");
+		assertEquals("en_GB", Context.getAdministrationService().getGlobalProperty("locale.allowed.list"));
+		Context.logout();
+
+		String value = null;
+		try {
+			value = dwr.getGlobalProperty("locale.allowed.list");
+		}
+		catch (APIAuthenticationException expected) {
+			// service-layer @Authorized rejected it on Platform 3.0+
+		}
+
+		assertEquals(null, value,
+		    "DWRAdministrationService.getGlobalProperty must not return a value to an unauthenticated caller. "
+		    + "If this fails, the DWR endpoint is leaking configuration to anyone who can reach /dwr/.");
+	}
+
+	/**
+	 * A logged-in user without {@code Manage Global Properties} must not be able
+	 * to mutate a global property through the DWR call. The underlying
+	 * {@code saveGlobalProperty} carries {@code @Authorized(MANAGE_GLOBAL_PROPERTIES)}
+	 * but the DWR method constructs a fresh {@link org.openmrs.GlobalProperty}
+	 * and calls save without first loading any managed entity, so this case is
+	 * not subject to the dirty-entity flush issue we observed for HL7 sources.
+	 * We assert the DB value is unchanged regardless.
+	 */
+	@Test
+	public void setGlobalProperty_shouldRejectUserWithoutManageGlobalPropertiesPrivilege() throws Exception {
+		Context.authenticate("admin", "test");
+		String originalValue = Context.getAdministrationService().getGlobalProperty("locale.allowed.list");
+		assertNotNull(originalValue);
+
+		// reuse the limited-user fixture from the HL7 test
+		executeDataSet("org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml");
+
+		Context.logout();
+		Context.authenticate("limiteduser", "test"); // no privileges
+
+		try {
+			dwr.setGlobalProperty("locale.allowed.list", "TAMPERED-VIA-DWR");
+		}
+		catch (APIAuthenticationException expected) {
+			// good — service-layer @Authorized rejected it
+		}
+
+		Context.logout();
+		Context.authenticate("admin", "test");
+
+		// read straight from the DB so we observe what is actually persisted
+		List<List<Object>> rows = Context.getAdministrationService()
+		    .executeSQL("select property_value from global_property where property = 'locale.allowed.list'", true);
+		assertEquals(1, rows.size(), "expected exactly one global_property row");
+		assertEquals(originalValue, rows.get(0).get(0),
+		    "A user without 'Manage Global Properties' must not be able to mutate a GP via DWR");
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/dwr/DWRHL7ServiceTest.java
+++ b/omod/src/test/java/org/openmrs/web/dwr/DWRHL7ServiceTest.java
@@ -1,0 +1,137 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.dwr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.hl7.Hl7InArchivesMigrateThread;
+import org.openmrs.web.security.DwrAuthorizationFilter;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Verifies that the request-boundary filter ({@link DwrAuthorizationFilter})
+ * blocks unauthorized DWR calls to {@link DWRHL7Service} <em>before</em> the
+ * DWR servlet dispatches them to the Java method. Tests that invoke the DWR
+ * class directly are not interesting here: the class has no auth check itself,
+ * and the static helpers it calls have no {@code @Authorized}, so a direct
+ * call will always succeed by design. The filter is the only thing standing
+ * between an HTTP attacker and the migration thread; this suite exercises
+ * exactly that boundary.
+ */
+public class DWRHL7ServiceTest extends BaseModuleWebContextSensitiveTest {
+
+	private DwrAuthorizationFilter filter;
+
+	private RecordingFilterChain chain;
+
+	@BeforeEach
+	public void initFilter() throws Exception {
+		filter = new DwrAuthorizationFilter();
+		filter.init(null);
+		chain = new RecordingFilterChain();
+	}
+
+	@AfterEach
+	public void resetMigrationState() {
+		try {
+			Hl7InArchivesMigrateThread.stopMigration();
+		}
+		catch (Exception ignore) {
+		}
+		Hl7InArchivesMigrateThread.setActive(false);
+		DWRHL7Service.setHl7MigrationThread(null);
+	}
+
+	@Test
+	public void startHl7ArchiveMigration_filterShouldRejectUnauthenticatedCaller() throws Exception {
+		Context.logout();
+
+		MockHttpServletRequest request = dwrRequest("DWRHL7Service", "startHl7ArchiveMigration");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(401, response.getStatus(),
+		    "An unauthenticated caller hitting the DWR migration endpoint must get 401, not be forwarded to the servlet");
+		assertFalse(chain.invoked, "Filter must not pass the request to the chain");
+		assertFalse(Hl7InArchivesMigrateThread.isActive(),
+		    "Migration must not have started while the filter was supposed to be rejecting the call");
+	}
+
+	@Test
+	public void startHl7ArchiveMigration_filterShouldRejectUserWithoutPrivilege() throws Exception {
+		executeDataSet("org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml");
+		Context.logout();
+		Context.authenticate("limiteduser", "test"); // no privileges
+
+		MockHttpServletRequest request = dwrRequest("DWRHL7Service", "startHl7ArchiveMigration");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(403, response.getStatus(),
+		    "An authenticated caller without 'Manage HL7 Messages' must get 403");
+		assertFalse(chain.invoked, "Filter must not pass the request to the chain");
+		assertFalse(Hl7InArchivesMigrateThread.isActive(),
+		    "Migration must not have started while the filter was supposed to be rejecting the call");
+	}
+
+	@Test
+	public void startHl7ArchiveMigration_filterShouldAllowAdmin() throws Exception {
+		Context.authenticate("admin", "test");
+
+		MockHttpServletRequest request = dwrRequest("DWRHL7Service", "startHl7ArchiveMigration");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(200, response.getStatus(), "admin must be allowed through the filter");
+		assertTrue(chain.invoked, "Filter must pass the request to the chain for an authorized caller");
+	}
+
+	@Test
+	public void filterShouldIgnoreNonMethodCallUrls() throws Exception {
+		Context.logout();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/openmrs/dwr/engine.js");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertTrue(chain.invoked,
+		    "Filter must let static DWR assets (engine.js, util.js, interface JS) pass through unauthenticated");
+	}
+
+	private MockHttpServletRequest dwrRequest(String script, String method) {
+		return new MockHttpServletRequest("POST", "/openmrs/dwr/call/plaincall/" + script + "." + method + ".dwr");
+	}
+
+	private static class RecordingFilterChain implements FilterChain {
+
+		boolean invoked = false;
+
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) {
+			invoked = true;
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/security/AuthorizationHandlerInterceptorTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/AuthorizationHandlerInterceptorTest.java
@@ -1,0 +1,190 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.web.WebConstants;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+
+/**
+ * Direct unit tests for {@link AuthorizationHandlerInterceptor#preHandle}. These tests do not
+ * exercise the Spring URL mapping or any controller; they construct the handler reference
+ * directly and assert the interceptor's authorization decisions.
+ */
+public class AuthorizationHandlerInterceptorTest extends BaseModuleWebContextSensitiveTest {
+
+	private static final String LIMITED_USER_DATASET = "org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml";
+
+	private AuthorizationHandlerInterceptor interceptor;
+
+	@BeforeEach
+	public void setUp() {
+		interceptor = new AuthorizationHandlerInterceptor();
+	}
+
+	@Test
+	public void preHandle_shouldAllowHandlerWithoutAnnotation() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/openmrs/admin/foo.htm");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, new UnannotatedHandler());
+
+		assertTrue(result, "Handler without @RequirePrivilege must be allowed (fail-open)");
+		assertEquals(200, response.getStatus());
+	}
+
+	@Test
+	public void preHandle_shouldRedirectUnauthenticatedCallerToLogin() throws Exception {
+		Context.logout();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/openmrs/admin/hl7/hl7Source.form");
+		request.setContextPath("/openmrs");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, new UpdateHl7SourceHandler());
+
+		assertFalse(result, "Interceptor must short-circuit unauthenticated callers");
+		assertEquals(302, response.getStatus());
+		assertEquals("/openmrs/login.htm", response.getRedirectedUrl());
+		assertEquals("require.login",
+		    request.getSession().getAttribute(WebConstants.OPENMRS_MSG_ATTR));
+		assertNotNull(request.getSession().getAttribute(WebConstants.OPENMRS_LOGIN_REDIRECT_HTTPSESSION_ATTR));
+	}
+
+	@Test
+	public void preHandle_shouldRedirectAuthenticatedCallerLackingPrivilege() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+		Context.logout();
+		Context.authenticate("limiteduser", "test");
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/openmrs/admin/hl7/hl7Source.form");
+		request.setContextPath("/openmrs");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, new UpdateHl7SourceHandler());
+
+		assertFalse(result, "Interceptor must reject authenticated callers without the required privilege");
+		assertEquals(302, response.getStatus());
+		assertEquals("/openmrs/login.htm", response.getRedirectedUrl());
+		assertEquals(Boolean.TRUE,
+		    request.getSession().getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES));
+		assertEquals("Update HL7 Source",
+		    request.getSession().getAttribute(WebConstants.REQUIRED_PRIVILEGES));
+	}
+
+	@Test
+	public void preHandle_shouldAllowAuthenticatedCallerWithPrivilege() throws Exception {
+		Context.authenticate("admin", "test");
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/openmrs/admin/hl7/hl7Source.form");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, new UpdateHl7SourceHandler());
+
+		assertTrue(result, "Caller with the required privilege must be allowed through");
+		assertNull(request.getSession(false) == null
+		        ? null
+		        : request.getSession().getAttribute(WebConstants.INSUFFICIENT_PRIVILEGES));
+	}
+
+	@Test
+	public void preHandle_authOnlyAnnotation_shouldRequireAuthenticationButNoPrivilege() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+		Context.logout();
+		Context.authenticate("limiteduser", "test"); // any authenticated user
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/openmrs/admin/something");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, new AuthOnlyHandler());
+
+		assertTrue(result, "Empty @RequirePrivilege must accept any authenticated caller");
+	}
+
+	@Test
+	public void preHandle_requireAllSemantics_shouldRejectIfAnyMissing() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+		Context.logout();
+		Context.authenticate("admin", "test"); // admin has all privileges, this passes
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/openmrs/admin/multi");
+		request.setContextPath("/openmrs");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		assertTrue(interceptor.preHandle(request, response, new RequireAllHandler()),
+		    "admin holds all listed privileges and must be allowed through");
+
+		// hl7reader has only Get HL7 Source, missing Update HL7 Source - require-all must reject
+		Context.logout();
+		Context.authenticate("hl7reader", "test");
+		MockHttpServletRequest request2 = new MockHttpServletRequest("POST", "/openmrs/admin/multi");
+		request2.setContextPath("/openmrs");
+		MockHttpServletResponse response2 = new MockHttpServletResponse();
+		assertFalse(interceptor.preHandle(request2, response2, new RequireAllHandler()),
+		    "Caller missing one of the required privileges must be rejected under require-all semantics");
+	}
+
+	@Test
+	public void preHandle_handlerMethod_shouldPreferMethodAnnotationOverClass() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+		Context.logout();
+		Context.authenticate("hl7reader", "test"); // has only Get HL7 Source
+
+		Method readMethod = AnnotatedController.class.getDeclaredMethod("read");
+		HandlerMethod handler = new HandlerMethod(new AnnotatedController(), readMethod);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/openmrs/admin/foo");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		boolean result = interceptor.preHandle(request, response, handler);
+
+		assertTrue(result, "Method-level @RequirePrivilege(Get HL7 Source) must override class-level "
+		    + "@RequirePrivilege(Update HL7 Source) so a hl7reader can hit a read handler");
+	}
+
+	@RequirePrivilege("Update HL7 Source")
+	private static class UpdateHl7SourceHandler {
+
+	}
+
+	@RequirePrivilege
+	private static class AuthOnlyHandler {
+
+	}
+
+	@RequirePrivilege(value = { "Get HL7 Source", "Update HL7 Source" }, requireAll = true)
+	private static class RequireAllHandler {
+
+	}
+
+	private static class UnannotatedHandler {
+
+	}
+
+	@RequirePrivilege("Update HL7 Source")
+	public static class AnnotatedController {
+
+		@RequirePrivilege("Get HL7 Source")
+		public void read() {
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterPrimaryPathTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterPrimaryPathTest.java
@@ -1,0 +1,113 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockServletContext;
+
+/**
+ * Covers the primary code path that {@link DwrAuthorizationFilterTest} cannot reach: resolving
+ * {@code WEB-INF/dwr-modules.xml} through a real {@link javax.servlet.FilterConfig}/
+ * {@link javax.servlet.ServletContext}, scanning it with {@link org.openmrs.util.OpenmrsClassLoader},
+ * and reloading on a change to the file's last-modified time. {@link DwrAuthorizationFilterTest}
+ * calls {@link DwrAuthorizationFilter#init(javax.servlet.FilterConfig)} with {@code null}, which
+ * only ever exercises the classpath fallback ({@code loadFallbackOnce}).
+ */
+public class DwrAuthorizationFilterPrimaryPathTest extends BaseModuleWebContextSensitiveTest {
+
+	private File webappRoot;
+
+	private File dwrXml;
+
+	private DwrAuthorizationFilter filter;
+
+	private RecordingFilterChain chain;
+
+	@BeforeEach
+	public void setUpFilter() throws Exception {
+		webappRoot = Files.createTempDirectory("dwr-webapp").toFile();
+		File webInf = new File(webappRoot, "WEB-INF");
+		assertTrue(webInf.mkdirs() || webInf.isDirectory());
+		dwrXml = new File(webInf, "dwr-modules.xml");
+		writeDwrXml(false);
+		// a "file:" resource base makes MockServletContext.getRealPath resolve into the temp dir
+		MockServletContext servletContext = new MockServletContext("file:" + webappRoot.getAbsolutePath());
+		filter = new DwrAuthorizationFilter();
+		filter.init(new MockFilterConfig(servletContext, "dwrAuthorization"));
+		chain = new RecordingFilterChain();
+	}
+
+	private void writeDwrXml(boolean includeStopMethod) throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<dwr>\n  <allow moduleId=\"legacyui\">\n"
+		        + "    <create creator=\"new\" javascript=\"DWRHL7Service\">\n"
+		        + "      <param name=\"class\" value=\"org.openmrs.web.dwr.DWRHL7Service\"/>\n"
+		        + "      <include method=\"startHl7ArchiveMigration\"/>\n"
+		        + (includeStopMethod ? "      <include method=\"stopHl7ArchiveMigration\"/>\n" : "")
+		        + "    </create>\n  </allow>\n</dwr>\n";
+		Files.write(dwrXml.toPath(), xml.getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void init_shouldScanAggregatedDwrModulesXmlNotClasspathFallback() {
+		// the fallback (legacyui's own config.xml) would register far more than one method
+		assertEquals(1, filter.getPrivilegesByScriptMethod().size());
+		assertNotNull(filter.getPrivilegesByScriptMethod().get("DWRHL7Service.startHl7ArchiveMigration"));
+	}
+
+	@Test
+	public void doFilter_shouldPickUpChangesToDwrModulesXml() throws Exception {
+		assertNull(filter.getPrivilegesByScriptMethod().get("DWRHL7Service.stopHl7ArchiveMigration"));
+
+		long before = dwrXml.lastModified();
+		writeDwrXml(true);
+		assertTrue(dwrXml.setLastModified(before + 5000), "must bump mtime past fs timestamp granularity");
+
+		Context.logout();
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.stopHl7ArchiveMigration.dwr");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(401, response.getStatus(),
+		    "after reload the method is annotated, so an unauthenticated call must be rejected");
+		assertFalse(chain.invoked);
+	}
+
+	private static class RecordingFilterChain implements FilterChain {
+
+		boolean invoked = false;
+
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) {
+			invoked = true;
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
@@ -57,11 +57,13 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 	@Test
 	public void init_everyDeclaredDwrMethodShouldBeAnnotated() {
-		// fail-closed contract: every method exposed in config.xml must carry @RequirePrivilege.
-		// If this fails, a developer has added a DWR method without annotating it; the filter
-		// will start up but reject that endpoint with 403 at request time.
+		// Best practice for legacyui's own DWR methods, not something this filter enforces:
+		// the filter itself fails open on a missing @RequirePrivilege (see class javadoc and
+		// doFilter_shouldPassUnannotatedMethodThroughWithoutAuth below), but there's no reason
+		// for legacyui's own classes to skip the annotation, so keep this as a completeness
+		// check on our own code.
 		assertTrue(filter.getUnannotatedMethods().isEmpty(),
-		    "All DWR methods must carry @RequirePrivilege. Unannotated: "
+		    "legacyui's own DWR methods should all carry @RequirePrivilege. Unannotated: "
 		            + filter.getUnannotatedMethods().keySet());
 	}
 
@@ -153,11 +155,15 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 	}
 
 	@Test
-	public void doFilter_unknownScriptMethod_shouldRejectEvenAdmin() throws Exception {
-		// fail-closed: any URL that doesn't resolve to a registered annotated method is 403,
-		// even for an admin. This protects against routing surprises and against future
-		// regressions where a method gets added to a DWR class but not config.xml.
-		Context.authenticate("admin", "test");
+	public void doFilter_unknownScriptMethod_shouldPassThroughEvenUnauthenticated() throws Exception {
+		// Fail-open: a {Script}.{method} pair this filter has no @RequirePrivilege for - whether
+		// because it's genuinely undeclared anywhere, or declared without the annotation - is
+		// passed straight to the chain, not blocked here. This is deliberate (see class javadoc):
+		// this filter only enforces what a module explicitly opted into via @RequirePrivilege.
+		// An unauthenticated caller is used here specifically to prove this isn't just "falls
+		// back to requiring auth" - login-style DWR methods (called before authentication) rely
+		// on exactly this.
+		Context.logout();
 
 		MockHttpServletRequest request = new MockHttpServletRequest("POST",
 		    "/openmrs/dwr/call/plaincall/NoSuchScript.noSuchMethod.dwr");
@@ -165,9 +171,8 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 		filter.doFilter(request, response, chain);
 
-		assertEquals(403, response.getStatus(),
-		    "Calls to {Script}.{method} pairs not declared in config.xml must be rejected even for admin");
-		assertFalse(chain.invoked);
+		assertTrue(chain.invoked,
+		    "Calls to {Script}.{method} pairs with no @RequirePrivilege must pass through, even unauthenticated");
 	}
 
 	private static class RecordingFilterChain implements FilterChain {

--- a/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
@@ -57,13 +57,11 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 	@Test
 	public void init_everyDeclaredDwrMethodShouldBeAnnotated() {
-		// Best practice for legacyui's own DWR methods, not something this filter enforces:
-		// the filter itself fails open on a missing @RequirePrivilege (see class javadoc and
-		// doFilter_shouldPassUnannotatedMethodThroughWithoutAuth below), but there's no reason
-		// for legacyui's own classes to skip the annotation, so keep this as a completeness
-		// check on our own code.
+		// fail-closed contract: every method exposed in config.xml must carry @RequirePrivilege.
+		// If this fails, a developer has added a DWR method without annotating it; the filter
+		// will start up but reject that endpoint with 403 at request time.
 		assertTrue(filter.getUnannotatedMethods().isEmpty(),
-		    "legacyui's own DWR methods should all carry @RequirePrivilege. Unannotated: "
+		    "All DWR methods must carry @RequirePrivilege. Unannotated: "
 		            + filter.getUnannotatedMethods().keySet());
 	}
 
@@ -155,15 +153,11 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 	}
 
 	@Test
-	public void doFilter_unknownScriptMethod_shouldPassThroughEvenUnauthenticated() throws Exception {
-		// Fail-open: a {Script}.{method} pair this filter has no @RequirePrivilege for - whether
-		// because it's genuinely undeclared anywhere, or declared without the annotation - is
-		// passed straight to the chain, not blocked here. This is deliberate (see class javadoc):
-		// this filter only enforces what a module explicitly opted into via @RequirePrivilege.
-		// An unauthenticated caller is used here specifically to prove this isn't just "falls
-		// back to requiring auth" - login-style DWR methods (called before authentication) rely
-		// on exactly this.
-		Context.logout();
+	public void doFilter_unknownScriptMethod_shouldRejectEvenAdmin() throws Exception {
+		// fail-closed: any URL that doesn't resolve to a registered annotated method is 403,
+		// even for an admin. This protects against routing surprises and against future
+		// regressions where a method gets added to a DWR class but not config.xml.
+		Context.authenticate("admin", "test");
 
 		MockHttpServletRequest request = new MockHttpServletRequest("POST",
 		    "/openmrs/dwr/call/plaincall/NoSuchScript.noSuchMethod.dwr");
@@ -171,8 +165,9 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 		filter.doFilter(request, response, chain);
 
-		assertTrue(chain.invoked,
-		    "Calls to {Script}.{method} pairs with no @RequirePrivilege must pass through, even unauthenticated");
+		assertEquals(403, response.getStatus(),
+		    "Calls to {Script}.{method} pairs not declared in config.xml must be rejected even for admin");
+		assertFalse(chain.invoked);
 	}
 
 	private static class RecordingFilterChain implements FilterChain {

--- a/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
@@ -1,0 +1,182 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.web.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openmrs.api.context.Context;
+import org.openmrs.web.test.jupiter.BaseModuleWebContextSensitiveTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * Direct unit tests for {@link DwrAuthorizationFilter}: URL parsing, startup scan of
+ * {@code config.xml}, and per-request authorization. These tests do not depend on the DWR
+ * servlet, on the DwrFilter rewrite, or on any specific DWR script class beyond the ones
+ * already declared in legacyui's {@code config.xml}.
+ */
+public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTest {
+
+	private static final String LIMITED_USER_DATASET = "org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml";
+
+	private DwrAuthorizationFilter filter;
+
+	private RecordingFilterChain chain;
+
+	@BeforeEach
+	public void setUp() throws Exception {
+		filter = new DwrAuthorizationFilter();
+		filter.init(null);
+		chain = new RecordingFilterChain();
+	}
+
+	@Test
+	public void init_shouldRegisterAtLeastTheAnnotatedHl7MigrationMethods() {
+		// these three are the pilot annotations; if init succeeded, the map must include them
+		assertNotNull(filter.getPrivilegesByScriptMethod().get("DWRHL7Service.startHl7ArchiveMigration"));
+		assertNotNull(filter.getPrivilegesByScriptMethod().get("DWRHL7Service.stopHl7ArchiveMigration"));
+		assertNotNull(filter.getPrivilegesByScriptMethod().get("DWRHL7Service.getMigrationStatus"));
+	}
+
+	@Test
+	public void init_everyDeclaredDwrMethodShouldBeAnnotated() {
+		// fail-closed contract: every method exposed in config.xml must carry @RequirePrivilege.
+		// If this fails, a developer has added a DWR method without annotating it; the filter
+		// will start up but reject that endpoint with 403 at request time.
+		assertTrue(filter.getUnannotatedMethods().isEmpty(),
+		    "All DWR methods must carry @RequirePrivilege. Unannotated: "
+		            + filter.getUnannotatedMethods().keySet());
+	}
+
+	@Test
+	public void extractScriptMethod_shouldParseStandardCallUrl() {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr");
+		assertEquals("DWRHL7Service.startHl7ArchiveMigration", filter.extractScriptMethod(request));
+	}
+
+	@Test
+	public void extractScriptMethod_shouldParseModuleServletPath() {
+		// the rewrite-target path that DwrFilter would normally forward to
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/ms/legacyui/dwr-invoker/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr");
+		assertEquals("DWRHL7Service.startHl7ArchiveMigration", filter.extractScriptMethod(request));
+	}
+
+	@Test
+	public void extractScriptMethod_shouldReturnNullForStaticAssets() {
+		assertNull(filter.extractScriptMethod(new MockHttpServletRequest("GET", "/openmrs/dwr/engine.js")));
+		assertNull(filter.extractScriptMethod(new MockHttpServletRequest("GET", "/openmrs/dwr/util.js")));
+		assertNull(filter.extractScriptMethod(new MockHttpServletRequest("GET",
+		    "/openmrs/dwr/interface/DWRPatientService.js")));
+	}
+
+	@Test
+	public void extractScriptMethod_shouldStripQueryString() {
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr?foo=bar");
+		// MockHttpServletRequest doesn't include query in getRequestURI() but we handle it defensively
+		assertEquals("DWRHL7Service.startHl7ArchiveMigration", filter.extractScriptMethod(request));
+	}
+
+	@Test
+	public void doFilter_shouldRejectUnauthenticatedCallerWith401() throws Exception {
+		Context.logout();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(401, response.getStatus());
+		assertFalse(chain.invoked);
+	}
+
+	@Test
+	public void doFilter_shouldRejectAuthenticatedCallerLackingPrivilegeWith403() throws Exception {
+		executeDataSet(LIMITED_USER_DATASET);
+		Context.logout();
+		Context.authenticate("limiteduser", "test");
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(403, response.getStatus());
+		assertFalse(chain.invoked);
+	}
+
+	@Test
+	public void doFilter_shouldAllowAuthenticatedCallerWithRequiredPrivilege() throws Exception {
+		Context.authenticate("admin", "test");
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/DWRHL7Service.startHl7ArchiveMigration.dwr");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertTrue(chain.invoked, "admin holds all migration privileges and must be passed to the chain");
+	}
+
+	@Test
+	public void doFilter_shouldPassStaticAssetsThroughWithoutAuth() throws Exception {
+		Context.logout();
+
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/openmrs/dwr/engine.js");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertTrue(chain.invoked,
+		    "Static DWR assets (engine.js, util.js, generated interface JS) must be reachable without auth");
+	}
+
+	@Test
+	public void doFilter_unknownScriptMethod_shouldRejectEvenAdmin() throws Exception {
+		// fail-closed: any URL that doesn't resolve to a registered annotated method is 403,
+		// even for an admin. This protects against routing surprises and against future
+		// regressions where a method gets added to a DWR class but not config.xml.
+		Context.authenticate("admin", "test");
+
+		MockHttpServletRequest request = new MockHttpServletRequest("POST",
+		    "/openmrs/dwr/call/plaincall/NoSuchScript.noSuchMethod.dwr");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		filter.doFilter(request, response, chain);
+
+		assertEquals(403, response.getStatus(),
+		    "Calls to {Script}.{method} pairs not declared in config.xml must be rejected even for admin");
+		assertFalse(chain.invoked);
+	}
+
+	private static class RecordingFilterChain implements FilterChain {
+
+		boolean invoked = false;
+
+		@Override
+		public void doFilter(ServletRequest request, ServletResponse response) {
+			invoked = true;
+		}
+	}
+}

--- a/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
+++ b/omod/src/test/java/org/openmrs/web/security/DwrAuthorizationFilterTest.java
@@ -57,11 +57,13 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 	@Test
 	public void init_everyDeclaredDwrMethodShouldBeAnnotated() {
-		// fail-closed contract: every method exposed in config.xml must carry @RequirePrivilege.
-		// If this fails, a developer has added a DWR method without annotating it; the filter
-		// will start up but reject that endpoint with 403 at request time.
+		// Best practice for legacyui's own DWR methods, not something this filter enforces:
+		// the filter itself fails open on a missing @RequirePrivilege (see class javadoc and
+		// doFilter_unknownScriptMethod_shouldPassThroughEvenUnauthenticated below), but there's no reason
+		// for legacyui's own classes to skip the annotation, so keep this as a completeness
+		// check on our own code.
 		assertTrue(filter.getUnannotatedMethods().isEmpty(),
-		    "All DWR methods must carry @RequirePrivilege. Unannotated: "
+		    "legacyui's own DWR methods should all carry @RequirePrivilege. Unannotated: "
 		            + filter.getUnannotatedMethods().keySet());
 	}
 
@@ -153,11 +155,15 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 	}
 
 	@Test
-	public void doFilter_unknownScriptMethod_shouldRejectEvenAdmin() throws Exception {
-		// fail-closed: any URL that doesn't resolve to a registered annotated method is 403,
-		// even for an admin. This protects against routing surprises and against future
-		// regressions where a method gets added to a DWR class but not config.xml.
-		Context.authenticate("admin", "test");
+	public void doFilter_unknownScriptMethod_shouldPassThroughEvenUnauthenticated() throws Exception {
+		// Fail-open: a {Script}.{method} pair this filter has no @RequirePrivilege for - whether
+		// because it's genuinely undeclared anywhere, or declared without the annotation - is
+		// passed straight to the chain, not blocked here. This is deliberate (see class javadoc):
+		// this filter only enforces what a module explicitly opted into via @RequirePrivilege.
+		// An unauthenticated caller is used here specifically to prove this isn't just "falls
+		// back to requiring auth" - login-style DWR methods (called before authentication) rely
+		// on exactly this.
+		Context.logout();
 
 		MockHttpServletRequest request = new MockHttpServletRequest("POST",
 		    "/openmrs/dwr/call/plaincall/NoSuchScript.noSuchMethod.dwr");
@@ -165,9 +171,8 @@ public class DwrAuthorizationFilterTest extends BaseModuleWebContextSensitiveTes
 
 		filter.doFilter(request, response, chain);
 
-		assertEquals(403, response.getStatus(),
-		    "Calls to {Script}.{method} pairs not declared in config.xml must be rejected even for admin");
-		assertFalse(chain.invoked);
+		assertTrue(chain.invoked,
+		    "Calls to {Script}.{method} pairs with no @RequirePrivilege must pass through, even unauthenticated");
 	}
 
 	private static class RecordingFilterChain implements FilterChain {

--- a/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
@@ -245,6 +245,41 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 	 * @see OpenmrsMessageTag#doEndTag()
 	 */
 	@Test
+	@Verifies(value = "write text attribute if no code specified and tag locale differs from context locale", method = "doEndTag()")
+	public void doEndTag_shouldWriteTextAttributeIfNoCodeSpecifiedAndTagLocaleDiffersFromContextLocale() throws Exception {
+		String expectedOutput = "Clinique Bon Sauveur";
+		openmrsMessageTag.setText(expectedOutput);
+		openmrsMessageTag.setLocale("uk");
+		
+		checkDoEndTagEvaluation(expectedOutput);
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
+	@Verifies(value = "write body content if no code specified and tag locale differs from context locale", method = "doEndTag()")
+	public void doEndTag_shouldWriteBodyContentIfNoCodeSpecifiedAndTagLocaleDiffersFromContextLocale() throws Exception {
+		String expectedOutput = "Clinique Bon Sauveur";
+		openmrsMessageTag.setBodyContent(new MockBodyContent(expectedOutput, new MockHttpServletResponse()));
+		openmrsMessageTag.setLocale("uk");
+		
+		checkDoEndTagEvaluation(expectedOutput);
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
+	@Verifies(value = "write an empty message if nothing can be resolved", method = "doEndTag()")
+	public void doEndTag_shouldWriteAnEmptyMessageIfNothingCanBeResolved() throws Exception {
+		checkDoEndTagEvaluation("");
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
 	@Verifies(value = "ignore fallbacks if tag locale differs from context locale", method = "doEndTag()")
 	public void doEndTag_shouldIgnoreFallbacksIfTagLocaleDiffersFromContextLocale() throws Exception {
 		String expectedOutput = "test.wrong.code";

--- a/omod/src/test/resources/org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml
+++ b/omod/src/test/resources/org/openmrs/web/controller/hl7/include/HL7SourceFormControllerTest.xml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+  <person person_id="507" gender="M" dead="false" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="f9a0e5a0-1234-4444-8888-aaaaaaaaaaaa"/>
+  <person_name person_name_id="507" preferred="true" person_id="507" given_name="Limited" middle_name=" " family_name="User" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="0e5a0f9a-1234-4444-8888-bbbbbbbbbbbb"/>
+  <users user_id="507" person_id="507" system_id="507-7" username="limiteduser" password="4a1750c8607d0fa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f" secret_question="" creator="1" date_created="2008-08-15 15:57:09.0" changed_by="1" date_changed="2008-08-18 11:51:56.0" retired="false" retire_reason="" uuid="aaaa0e5a-1234-4444-8888-cccccccccccc"/>
+
+  <privilege privilege="Get HL7 Source" description="Able to view HL7 sources" uuid="bbbb0e5a-1234-4444-8888-aaaaaaaa1111"/>
+
+  <person person_id="508" gender="F" dead="false" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="f9a0e5a0-1234-4444-8888-dddddddddddd"/>
+  <person_name person_name_id="508" preferred="true" person_id="508" given_name="HL7" middle_name=" " family_name="Reader" creator="1" date_created="2008-08-15 15:46:47.0" voided="false" uuid="0e5a0f9a-1234-4444-8888-eeeeeeeeeeee"/>
+  <users user_id="508" person_id="508" system_id="508-3" username="hl7reader" password="4a1750c8607d0fa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f" secret_question="" creator="1" date_created="2008-08-15 15:57:09.0" changed_by="1" date_changed="2008-08-18 11:51:56.0" retired="false" retire_reason="" uuid="aaaa0e5a-1234-4444-8888-ffffffffffff"/>
+
+  <role role="HL7 Reader" description="Can view HL7 sources but not modify them" uuid="bbbb0e5a-1234-4444-8888-111111111111"/>
+  <role_privilege role="HL7 Reader" privilege="Get HL7 Source"/>
+  <user_role user_id="508" role="HL7 Reader"/>
+</dataset>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>legacyui</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0</version>
 	<packaging>pom</packaging>
 	<name>Legacy UI Module</name>
 	<description>Provides the legacy UI which was removed from the platform since version 2.0</description>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</developerConnection>
         <url>https://github.com/openmrs/openmrs-module-legacyui.git</url>
-      <tag>HEAD</tag>
+      <tag>2.1.0</tag>
   </scm>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>legacyui</artifactId>
-	<version>2.1.0</version>
+	<version>2.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Legacy UI Module</name>
 	<description>Provides the legacy UI which was removed from the platform since version 2.0</description>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</developerConnection>
         <url>https://github.com/openmrs/openmrs-module-legacyui.git</url>
-      <tag>2.1.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 	
 	<properties>
 		<openmrsPlatformVersion>2.7.3</openmrsPlatformVersion>
-		<openmrsContribDwrVersion>2.0.8-mod</openmrsContribDwrVersion>
+		<openmrsContribDwrVersion>2.0.9-mod</openmrsContribDwrVersion>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaCompilerVersion>8</javaCompilerVersion>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>legacyui</artifactId>
-	<version>2.2.0</version>
+	<version>2.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Legacy UI Module</name>
 	<description>Provides the legacy UI which was removed from the platform since version 2.0</description>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</developerConnection>
         <url>https://github.com/openmrs/openmrs-module-legacyui.git</url>
-      <tag>2.2.0</tag>
+      <tag>HEAD</tag>
   </scm>
 
 	<modules>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>legacyui</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0</version>
 	<packaging>pom</packaging>
 	<name>Legacy UI Module</name>
 	<description>Provides the legacy UI which was removed from the platform since version 2.0</description>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</connection>
         <developerConnection>scm:git:git@github.com:openmrs/openmrs-module-legacyui.git</developerConnection>
         <url>https://github.com/openmrs/openmrs-module-legacyui.git</url>
-      <tag>HEAD</tag>
+      <tag>2.2.0</tag>
   </scm>
 
 	<modules>


### PR DESCRIPTION
This is just a simple safeguard against text without code. Here is the complete analysis for this issue:
`⏺ Root cause

  omod/src/main/webapp/tags/locationTree.tag:78 renders the encounter's location with:

  <openmrs:message javaScriptEscape="true" text="${initialValue.name}"/>

  i.e. a text attribute with no code. In OpenmrsMessageTag.resolveMessage() the text/body was only honored when the tag's locale matched the user's locale:

  if (OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage()))

  this.locale defaults to LocaleUtility.getDefaultLocale().getLanguage() — the system default locale (the default_locale global property), not the user's. On your dev instance that property resolves to French,
  so:

  - Viewing in fr → "fr".equals("fr") → the location name is used → page renders.
  - Viewing in en → "fr".equals("en") is false → text is discarded, code is null, body is null → resolveMessage() returns null → HtmlUtils.htmlEscape(null) at OpenmrsMessageTag.java:199 throws
    IllegalArgumentException: Input is required.

  That locale gate is meant for a localized fallback of a code (<openmrs:message code="foo" locale="fr">Bonjour</openmrs:message>). With no code there is nothing to look up, so gating on locale can only produce
  null. Same latent crash exists at patientDashboardForm.jsp:10, portlets/findPatient.jsp:186, portlets/globalProperties.jsp:78.

  Fix

  omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java:

  1. resolveMessage() — apply the locale gate only when a code is actually set; with no code, the text/body is the message and is always used.
  2. doEndTagInternal() — treat an unresolvable message as "" instead of null, so a null can never blow up the whole page through HtmlUtils.htmlEscape / JavaScriptUtils.javaScriptEscape again.

  Three regression tests added in OpenmrsMessageTagTest. Verified they fail against the unpatched tag (expected:<[Clinique Bon Sauveur]> but was:<[null]>) and pass with the fix; all 52 taglib tests pass.

  Note this is a legacyui fix — nothing in openmrs-core needs changing; LocaleUtility.getDefaultLocale() behaved correctly. You can also confirm the trigger by checking the default_locale global property on
  your instance — it should be non-English.`