### PR TITLE
LUI-214: safeguard against text without code

### DIFF
--- a/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
+++ b/omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java
@@ -39,11 +39,13 @@ import org.springframework.web.util.TagUtils;
  * addition) this tag uses its body text when the code cannot be resolved. If the body value also is
  * not specified, the value of the text attribute is used. If there is no message in the bundle and
  * no text attribute value or tag body text, then the message code is displayed, if it is set;
- * otherwise null. If both text attribute and body text are present (shouldn't happen, but could by
- * mistake), then this tag uses the body text before checking the text attribute. With this tag user
- * can define default text for a locale other than the system default by using locale attribute. If
- * locale attribute is not specified, then the system default locale (e.g., "en") will be used. HTML
- * escaping is also supported by this tag.
+ * otherwise an empty string. If both text attribute and body text are present (shouldn't happen,
+ * but could by mistake), then this tag uses the body text before checking the text attribute. With
+ * this tag user can define default text for a locale other than the system default by using locale
+ * attribute. If locale attribute is not specified, then the system default locale (e.g., "en") will
+ * be used. Note that the locale attribute only applies to fallbacks of a message code; when no code
+ * is given, the text attribute or the tag body is the message itself and is always written out.
+ * HTML escaping is also supported by this tag.
  * </p>
  * <p>
  * This tag also supports customization of messages writing behavior. To change its default
@@ -192,8 +194,12 @@ public class OpenmrsMessageTag extends OpenmrsHtmlEscapingAwareTag {
 	@Override
 	protected int doEndTagInternal() throws JspException, IOException {
 		try {
-			// Resolve the unescaped message.
+			// Resolve the unescaped message. Nothing resolvable leaves us with an empty message, but
+			// never with null, as the escaping utilities below reject null input.
 			String msg = resolveMessage();
+			if (msg == null) {
+				msg = "";
+			}
 			
 			// HTML and/or JavaScript escape, if demanded.
 			msg = isHtmlEscape() ? HtmlUtils.htmlEscape(msg) : msg;
@@ -242,8 +248,12 @@ public class OpenmrsMessageTag extends OpenmrsHtmlEscapingAwareTag {
 		String resolvedCode = this.code;
 		String bodyText = null;
 		String resolvedText = null;
-		// if locale specified with tag attribute is the same as context locale
-		if (OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage())) {
+		// The locale attribute only qualifies the text/body as a *fallback* for a message code, so it
+		// is only meaningful when a code was given. When no code is set, the text attribute (or the tag
+		// body) is the message itself and has to be used whatever locale the user is viewing in,
+		// otherwise nothing at all would be resolved.
+		if (!StringUtils.hasText(resolvedCode)
+		        || OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage())) {
 			// we need to evaluate fallback values in this case
 			resolvedText = this.text;
 			if (getBodyContent() != null) {

--- a/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
+++ b/omod/src/test/java/org/openmrs/web/taglib/OpenmrsMessageTagTest.java
@@ -245,6 +245,41 @@ public class OpenmrsMessageTagTest extends BaseModuleWebContextSensitiveTest {
 	 * @see OpenmrsMessageTag#doEndTag()
 	 */
 	@Test
+	@Verifies(value = "write text attribute if no code specified and tag locale differs from context locale", method = "doEndTag()")
+	public void doEndTag_shouldWriteTextAttributeIfNoCodeSpecifiedAndTagLocaleDiffersFromContextLocale() throws Exception {
+		String expectedOutput = "Clinique Bon Sauveur";
+		openmrsMessageTag.setText(expectedOutput);
+		openmrsMessageTag.setLocale("uk");
+		
+		checkDoEndTagEvaluation(expectedOutput);
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
+	@Verifies(value = "write body content if no code specified and tag locale differs from context locale", method = "doEndTag()")
+	public void doEndTag_shouldWriteBodyContentIfNoCodeSpecifiedAndTagLocaleDiffersFromContextLocale() throws Exception {
+		String expectedOutput = "Clinique Bon Sauveur";
+		openmrsMessageTag.setBodyContent(new MockBodyContent(expectedOutput, new MockHttpServletResponse()));
+		openmrsMessageTag.setLocale("uk");
+		
+		checkDoEndTagEvaluation(expectedOutput);
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
+	@Verifies(value = "write an empty message if nothing can be resolved", method = "doEndTag()")
+	public void doEndTag_shouldWriteAnEmptyMessageIfNothingCanBeResolved() throws Exception {
+		checkDoEndTagEvaluation("");
+	}
+	
+	/**
+	 * @see OpenmrsMessageTag#doEndTag()
+	 */
+	@Test
 	@Verifies(value = "ignore fallbacks if tag locale differs from context locale", method = "doEndTag()")
 	public void doEndTag_shouldIgnoreFallbacksIfTagLocaleDiffersFromContextLocale() throws Exception {
 		String expectedOutput = "test.wrong.code";


### PR DESCRIPTION
This is just a simple safeguard against text without code. Here is the complete analysis for this issue:
`⏺ Root cause

omod/src/main/webapp/tags/locationTree.tag:78 renders the encounter's location with:

<openmrs:message javaScriptEscape="true" text="${initialValue.name}"/>

i.e. a text attribute with no code. In OpenmrsMessageTag.resolveMessage() the text/body was only honored when the tag's locale matched the user's locale:

if (OpenmrsUtil.nullSafeEquals(this.locale, Context.getLocale().getLanguage()))

this.locale defaults to LocaleUtility.getDefaultLocale().getLanguage() — the system default locale (the default_locale global property), not the user's. On your dev instance that property resolves to French,
so:

Viewing in fr → "fr".equals("fr") → the location name is used → page renders.
Viewing in en → "fr".equals("en") is false → text is discarded, code is null, body is null → resolveMessage() returns null → HtmlUtils.htmlEscape(null) at OpenmrsMessageTag.java:199 throws
IllegalArgumentException: Input is required.
That locale gate is meant for a localized fallback of a code (<openmrs:message code="foo" locale="fr">Bonjour</openmrs:message>). With no code there is nothing to look up, so gating on locale can only produce
null. Same latent crash exists at patientDashboardForm.jsp:10, portlets/findPatient.jsp:186, portlets/globalProperties.jsp:78.

Fix

omod/src/main/java/org/openmrs/web/taglib/OpenmrsMessageTag.java:

resolveMessage() — apply the locale gate only when a code is actually set; with no code, the text/body is the message and is always used.
doEndTagInternal() — treat an unresolvable message as "" instead of null, so a null can never blow up the whole page through HtmlUtils.htmlEscape / JavaScriptUtils.javaScriptEscape again.
Three regression tests added in OpenmrsMessageTagTest. Verified they fail against the unpatched tag (expected:<[Clinique Bon Sauveur]> but was:<[null]>) and pass with the fix; all 52 taglib tests pass.

Note this is a legacyui fix — nothing in openmrs-core needs changing; LocaleUtility.getDefaultLocale() behaved correctly. You can also confirm the trigger by checking the default_locale global property on
your instance — it should be non-English.`